### PR TITLE
Feature/Add Wiki Version Information to Docs  [PLAT-469]

### DIFF
--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -50,6 +50,7 @@ x-tagGroups:
       - Taxonomies
       - Users
       - View Only Links
+      - Wikis
 tags:
   - name: Introduction
     x-traitTag: true
@@ -1095,3 +1096,12 @@ paths:
 
   /wikis/{wiki_id}/content/:
     $ref: 'wikis/content.yaml'
+
+  /wikis/{wiki_id}/versions/:
+    $ref: 'wikis/versions_list.yaml'
+
+  /wikis/{wiki_id}/versions/{version_id}/:
+    $ref: 'wikis/version_detail.yaml'
+
+  /wikis/{wiki_id}/versions/{version_id}/content/:
+    $ref: 'wikis/version_content.yaml'

--- a/swagger-spec/wikis/definition.yaml
+++ b/swagger-spec/wikis/definition.yaml
@@ -74,6 +74,7 @@ properties:
       - node
       - user
       - comments
+      - versions
     properties:
       node:
         type: string
@@ -87,6 +88,10 @@ properties:
         type: string
         readOnly: false
         description: 'A relationship to the comments related to this wiki.'
+      versions:
+        type: string
+        readOnly: false
+        description: 'A relationship to the versions related to this wiki.'
   links:
     type: object
     title: Links

--- a/swagger-spec/wikis/detail.yaml
+++ b/swagger-spec/wikis/detail.yaml
@@ -1,3 +1,4 @@
+# /wikis/{wiki_id}/
 get:
   summary: Retrieve a Wiki
   description: >-
@@ -5,8 +6,6 @@ get:
 
     A wiki is a collection of markdown text pages that can be used to describe
     the project or dataset of contained in the attached node.
-
-    ####Returns
 
     Returns a JSON object with a `data` key containing the representation of the requested
     wiki, if the request was successful.
@@ -44,6 +43,11 @@ get:
                 links:
                   related:
                     href: 'https://api.osf.io/v2/users/5k3hq/'
+                    meta: {}
+              versions:
+                links:
+                  related:
+                    href: 'https://api.osf.io/v2/wikis/zveyb/versions/'
                     meta: {}
               comments:
                 links:

--- a/swagger-spec/wikis/version_content.yaml
+++ b/swagger-spec/wikis/version_content.yaml
@@ -1,0 +1,28 @@
+# /wikis/{wiki_id}/versions/{version_id}/content/
+get:
+  summary: Retrieve the Content of a Wiki Version
+  description: >-
+    Retrieves the plaintext content of a specific wiki version in markdown format.
+
+    Returns `text/markdown` of the wiki content itself.
+
+    If the request is unsuccessful, plaintext with the error message will be displayed.
+
+  parameters:
+    - in: path
+      type: string
+      required: true
+      name: wiki_id
+      description: 'The unique identifier of the wiki.'
+    - in: path
+      type: string
+      required: true
+      name: version_id
+      description: 'The unique identifier of the wiki version'
+  tags:
+    - Wikis
+  operationId: wiki_version_content
+  x-response-schema: Wiki
+  responses:
+    '200':
+      description: 'OK'

--- a/swagger-spec/wikis/version_definition.yaml
+++ b/swagger-spec/wikis/version_definition.yaml
@@ -1,0 +1,70 @@
+type: object
+title: Wiki
+required:
+  - type
+  - relationships
+properties:
+  id:
+    type: string
+    readOnly: true
+    description: 'The wiki version.'
+  type:
+    type: string
+    readOnly: false
+    description: 'The type identifier of the wiki version (`wiki-versions`).'
+  attributes:
+    type: object
+    title: Attributes
+    readOnly: false
+    description: 'The properties of the wiki version.'
+    required:
+      - date_created
+      - content_type
+      - size
+    properties:
+      date_created:
+        type: string
+        format: date-time
+        readOnly: true
+        description: 'The date and time at which the wiki version was saved, as an iso8601 formatted timestamp.'
+      content_type:
+        type: string
+        readOnly: true
+        description: 'Content type of the wiki version (`text/markdown`).'
+      size:
+        type: string
+        readOnly: true
+        description: 'Size of the wiki version.'
+  relationships:
+    type: object
+    title: Relationships
+    readOnly: false
+    description: 'URLs to other entities or entity collections that have a relationship to the wiki version.'
+    required:
+      - wiki_page
+      - user
+    properties:
+      wiki_page:
+        type: string
+        readOnly: false
+        description: 'A relationship to the associated wiki.'
+      user:
+        type: string
+        readOnly: false
+        description: 'A relationship to the user associated with this wiki version.'
+  links:
+    type: object
+    title: Links
+    readOnly: true
+    description: 'URLs to alternative representations of the wiki version.'
+    properties:
+      download:
+        type: string
+        format: URL
+        readOnly: true
+        description: 'The URL to download the content of the wiki version.'
+      self:
+        type: string
+        format: URL
+        readOnly: true
+        description: 'A link to the detail page for the wiki version.'

--- a/swagger-spec/wikis/version_detail.yaml
+++ b/swagger-spec/wikis/version_detail.yaml
@@ -1,0 +1,59 @@
+# /wikis/{wiki_id}/versions/{version_id}/
+get:
+  summary: Retrieve a Wiki Version
+  description: >-
+    A wiki is a collection of markdown text pages that can be used to describe
+    the project or dataset contained in the attached node.  Every time the content
+    of a wiki is updated, a new version is created.
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    wiki, if the request was successful.
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
+    to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      required: true
+      name: wiki_id
+      description: 'The unique identifier of the wiki.'
+    - in: path
+      type: string
+      required: true
+      name: version_id
+      description: 'The unique identifier of the wiki version'
+  tags:
+    - Wikis
+  operationId: wiki_version_detail
+  x-response-schema: Wiki
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: 'version_definition.yaml'
+      examples:
+        application/json:
+          data:
+            relationships:
+              wiki_page:
+                links:
+                  related:
+                    href: 'https://api.osf.io/v2/wikis/3va7z/'
+                    meta: {}
+              user:
+                links:
+                  related:
+                    href: 'https://api.osf.io/v2/users/nrws6/'
+                    meta: {}
+            links:
+              download: 'https://api.osf.io/v2/wikis/3va7z/versions/2/content/'
+              self: 'https://api.osf.io/v2/wikis/3va7z/versions/2/'
+            attributes:
+              date_created: '2018-02-17T01:39:09.930740'
+              content_type: 'text/markdown'
+              size: 115
+            type: 'wiki-versions'
+            id: '2'

--- a/swagger-spec/wikis/versions_list.yaml
+++ b/swagger-spec/wikis/versions_list.yaml
@@ -1,0 +1,78 @@
+# /wikis/{wiki_id}/versions/
+get:
+  summary: Retrieve all Wiki Versions
+  description: >-
+    Retrieves all versions of a wiki.
+
+    A wiki is a collection of markdown text pages that can be used to describe
+    the project or dataset contained in the attached node.  Every time the content
+    of a wiki is updated, a new version is created.
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    wiki, if the request was successful.
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#Introduction_error_codes)
+    to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      required: true
+      name: wiki_id
+      description: 'The unique identifier of the wiki.'
+  tags:
+    - Wikis
+  operationId: wiki_versions_list
+  x-response-schema: Wiki
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        type: array
+        items:
+          $ref: 'version_definition.yaml'
+      examples:
+        application/json:
+          data:
+          - relationships:
+              wiki_page:
+                links:
+                  related:
+                    href: 'https://api.osf.io/v2/wikis/3va7z/'
+                    meta: {}
+              user:
+                links:
+                  related:
+                    href: 'https://api.osf.io/v2/users/nrws6/'
+                    meta: {}
+            links:
+              download: 'https://api.osf.io/v2/wikis/3va7z/versions/2/content/'
+              self: 'https://api.osf.io/v2/wikis/3va7z/versions/2/'
+            attributes:
+              date_created: '2018-02-17T01:39:09.930740'
+              content_type: 'text/markdown'
+              size: 115
+            type: 'wiki-versions'
+            id: '2'
+          - relationships:
+              wiki_page:
+                links:
+                  related:
+                    href: 'https://api.osf.io/v2/wikis/3va7z/'
+                    meta: {}
+              user:
+                links:
+                  related:
+                    href: 'https://api.osf.io/v2/users/nrws6/'
+                    meta: {}
+            links:
+              download: 'https://api.osf.io/v2/wikis/3va7z/versions/1/content/'
+              self: 'https://api.osf.io/v2/wikis/3va7z/versions/1/'
+            attributes:
+              date_created: '2017-02-16T15:45:57.671957'
+              content_type: 'text/markdown'
+              size: 108
+            type: 'wiki-versions'
+            id: '1'


### PR DESCRIPTION
# Purpose

Add Wiki Version information to docs and surface Wiki information

# Changes
### Endpoints
- wikis/<wiki_id>/
- wikis/<wiki_id>/content/
- wikis/<wiki_id>/versions/
- wikis/<wiki_id>/versions/<version_id>
- wikis/<wiki_id>/versions/<version_id>/content/

![screen shot 2018-02-19 at 6 11 29 pm](https://user-images.githubusercontent.com/9755598/36401974-ba79ee88-15a0-11e8-84b5-4dcad33b84d8.png)

![screen shot 2018-02-19 at 6 11 40 pm](https://user-images.githubusercontent.com/9755598/36401959-a630ecba-15a0-11e8-9711-2ddc3c43898c.png)

![screen shot 2018-02-19 at 6 12 06 pm](https://user-images.githubusercontent.com/9755598/36401964-a95dcd22-15a0-11e8-9e86-d12705f147ed.png)

![screen shot 2018-02-19 at 6 12 29 pm](https://user-images.githubusercontent.com/9755598/36401966-ac072e88-15a0-11e8-9fd2-357c62115c67.png)

![screen shot 2018-02-19 at 6 12 54 pm](https://user-images.githubusercontent.com/9755598/36401968-b3bd0062-15a0-11e8-91ca-9722e5c2cdfe.png)
