### PR TITLE
[IN-227][DeveloperDocs] Deprecate preprint_providers

### DIFF
--- a/swagger-spec/preprint_providers/definition.yaml
+++ b/swagger-spec/preprint_providers/definition.yaml
@@ -15,10 +15,6 @@ properties:
     readOnly: true
     description: 'The properties of the preprint provider entity.'
     properties:
-      social_instagram:
-        type: string
-        readOnly: true
-        description: 'The preprint provider''s Instagram account ID. This field is deprecated as of verson 2.4.'
       advisory_board:
         type: string
         readOnly: true
@@ -27,30 +23,10 @@ properties:
         type: string
         readOnly: true
         description: 'The preprint providers''s support email address.'
-      banner_path:
-        type: string
-        readOnly: true
-        description: 'A static path to the preprint provider''s banner image. This field is deprecated as of verson 2.4.'
-      logo_path:
-        type: string
-        readOnly: true
-        description: 'A static path to the preprint provider''s logo image. This field is deprecated as of verson 2.4.'
-      subjects_acceptable:
-        type: string
-        readOnly: true
-        description: 'A nested array structure defining allowed subjects for this preprint provider, in the BePress taxonomy.'
       description:
         type: string
         readOnly: true
         description: 'The description of the preprint provider.'
-      social_facebook:
-        type: string
-        readOnly: true
-        description: 'The preprint provider''s Facebook account ID. This field is deprecated as of verson 2.4.'
-      email_contact:
-        type: string
-        readOnly: true
-        description: 'The preprint provider''s contact email address. This field is deprecated as of verson 2.4.'
       example:
         type: string
         readOnly: true

--- a/swagger-spec/preprint_providers/detail.yaml
+++ b/swagger-spec/preprint_providers/detail.yaml
@@ -4,7 +4,7 @@ get:
     Retrieves the details of a preprint provider.
 
 
-    _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+    _< v2.7 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/detail.yaml
+++ b/swagger-spec/preprint_providers/detail.yaml
@@ -4,7 +4,7 @@ get:
     Retrieves the details of a preprint provider.
 
 
-    _< v2.7 use `preprint_providers` instead of `providers/preprints`_
+    _< v2.8 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/detail.yaml
+++ b/swagger-spec/preprint_providers/detail.yaml
@@ -19,59 +19,6 @@ get:
     to understand why this request may have failed.
 
 
-    #### Acceptable Subjects Structure
-
-
-    Each preprint provider specifies acceptable subjects.
-
-
-    `subjects_acceptable` is an array found in `attributes`.
-
-
-    Subjects consist of general parent subjects (e.g., Engineering),
-    more specific child subjects (e.g., Aerospace Engineering),
-    and even more specific grandchild subjects (e.g., Aerodynamics and Fluid Mechanics).
-    Subjects can only be nested 3 deep.
-
-
-        "subjects_acceptable": [
-            [
-                [
-                    # Parent Subject:
-                    # Architecture
-                    "584240d954be81056ceca9e5",
-
-                    # Child Subject:
-                    # Architectural Engineering
-                    "584240da54be81056cecac87"
-                ],
-                # Include all Architectural Engineering's children:
-                true
-            ],
-            [
-                [
-                    # Parent Subject:
-                    # Engineering
-                    "584240da54be81056cecaca9",
-
-                    # Child Subject:
-                    # Aerospace Engineering
-                    "584240db54be81056cecacd6",
-
-                    # Grandchild Subject:
-                    # Aerodynamics and Fluid Mechanics
-                    "584240da54be81056cecaa74"
-                ],
-                # All nestings 3 deep must be false
-                false
-            ]
-        ]
-
-
-    The above structure would allow Architecture, Architectural Engineering, all of Architectural Engineering's children,
-    Engineering, Aerospace Engineering, and Aerodynamics and Fluid Mechanics.
-
-
   parameters:
     - in: path
       type: string
@@ -111,17 +58,9 @@ get:
               preprints: https://api.osf.io/v2/providers/preprints/osf/preprints/
               external_url: https://osf.io/preprints/
             attributes:
-              social_instagram: ''
               advisory_board: ''
               email_support: ''
-              banner_path: "/static/img/providers/preprints/cos-logo.png"
-              logo_path: "/static/img/providers/preprints/cos-logo.png"
-              subjects_acceptable: []
               description: A scholarly commons to connect the entire research cycle
-              social_facebook: ''
-              header_text: ''
-              social_twitter: ''
-              email_contact: ''
               example: khbvy
               name: Open Science Framework
               domain: 'osf.io'

--- a/swagger-spec/preprint_providers/detail.yaml
+++ b/swagger-spec/preprint_providers/detail.yaml
@@ -4,6 +4,9 @@ get:
     Retrieves the details of a preprint provider.
 
 
+    _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+
+
     #### Returns
 
 
@@ -91,28 +94,28 @@ get:
               licenses_acceptable:
                 links:
                   related:
-                    href: https://api.osf.io/v2/preprint_providers/osf/licenses/
+                    href: https://api.osf.io/v2/providers/preprints/osf/licenses/
                     meta: {}
               taxonomies:
                 links:
                   related:
-                    href: https://api.osf.io/v2/preprint_providers/osf/taxonomies/
+                    href: https://api.osf.io/v2/providers/preprints/osf/taxonomies/
                     meta: {}
               preprints:
                 links:
                   related:
-                    href: https://api.osf.io/v2/preprint_providers/osf/preprints/
+                    href: https://api.osf.io/v2/providers/preprints/osf/preprints/
                     meta: {}
             links:
-              self: https://api.osf.io/v2/preprint_providers/osf/
-              preprints: https://api.osf.io/v2/preprint_providers/osf/preprints/
+              self: https://api.osf.io/v2/providers/preprints/osf/
+              preprints: https://api.osf.io/v2/providers/preprints/osf/preprints/
               external_url: https://osf.io/preprints/
             attributes:
               social_instagram: ''
               advisory_board: ''
               email_support: ''
-              banner_path: "/static/img/preprint_providers/cos-logo.png"
-              logo_path: "/static/img/preprint_providers/cos-logo.png"
+              banner_path: "/static/img/providers/preprints/cos-logo.png"
+              logo_path: "/static/img/providers/preprints/cos-logo.png"
               subjects_acceptable: []
               description: A scholarly commons to connect the entire research cycle
               social_facebook: ''

--- a/swagger-spec/preprint_providers/licenses_list.yaml
+++ b/swagger-spec/preprint_providers/licenses_list.yaml
@@ -4,7 +4,7 @@ get:
     A paginated list of the licenses allowed bya preprint provider.
 
 
-    _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+    _< v2.7 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/licenses_list.yaml
+++ b/swagger-spec/preprint_providers/licenses_list.yaml
@@ -4,7 +4,7 @@ get:
     A paginated list of the licenses allowed bya preprint provider.
 
 
-    _< v2.7 use `preprint_providers` instead of `providers/preprints`_
+    _< v2.8 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/licenses_list.yaml
+++ b/swagger-spec/preprint_providers/licenses_list.yaml
@@ -4,6 +4,9 @@ get:
     A paginated list of the licenses allowed bya preprint provider.
 
 
+    _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+
+
     #### Returns
 
 

--- a/swagger-spec/preprint_providers/list.yaml
+++ b/swagger-spec/preprint_providers/list.yaml
@@ -9,7 +9,7 @@ get:
     preprints appearing first.
 
 
-    _< v2.7 use `preprint_providers` instead of `providers/preprints`_
+    _< v2.8 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/list.yaml
+++ b/swagger-spec/preprint_providers/list.yaml
@@ -1,4 +1,4 @@
-# /preprint_providers/
+# /providers/preprints/
 get:
   summary: List all preprint providers
   description: >-
@@ -7,6 +7,9 @@ get:
 
     The returned preprint providers are sorted by their creation date, with the most recent
     preprints appearing first.
+
+
+    _< v2.7 use`prepint_providers` instead of `providers/preprints`_
 
 
     #### Returns
@@ -33,7 +36,7 @@ get:
 
     You can optionally request that the response only include preprint providers that
     match your filters by utilizing the `filter` query parameter, e.g.
-    https://api.osf.io/v2/preprint_providers/?filter[id]=osf.
+    https://api.osf.io/v2/providers/preprints/?filter[id]=osf.
 
 
     Preprint Providers may be filtered by their `id`, `name`,  and `description`
@@ -58,28 +61,28 @@ get:
                 licenses_acceptable:
                   links:
                     related:
-                      href: https://api.osf.io/v2/preprint_providers/osf/licenses/
+                      href: https://api.osf.io/v2/providers/preprints/osf/licenses/
                       meta: {}
                 taxonomies:
                   links:
                     related:
-                      href: https://api.osf.io/v2/preprint_providers/osf/taxonomies/
+                      href: https://api.osf.io/v2/providers/preprints/osf/taxonomies/
                       meta: {}
                 preprints:
                   links:
                     related:
-                      href: https://api.osf.io/v2/preprint_providers/osf/preprints/
+                      href: https://api.osf.io/v2/providers/preprints/osf/preprints/
                       meta: {}
               links:
-                self: https://api.osf.io/v2/preprint_providers/osf/
-                preprints: https://api.osf.io/v2/preprint_providers/osf/preprints/
+                self: https://api.osf.io/v2/providers/preprints/osf/
+                preprints: https://api.osf.io/v2/providers/preprints/osf/preprints/
                 external_url: https://osf.io/preprints/
               attributes:
                 social_instagram: ''
                 advisory_board: ''
                 email_support: ''
-                banner_path: "/static/img/preprint_providers/cos-logo.png"
-                logo_path: "/static/img/preprint_providers/cos-logo.png"
+                banner_path: "/static/img/providers/preprints/cos-logo.png"
+                logo_path: "/static/img/providers/preprints/cos-logo.png"
                 subjects_acceptable: []
                 description: A scholarly commons to connect the entire research cycle
                 social_facebook: ''

--- a/swagger-spec/preprint_providers/list.yaml
+++ b/swagger-spec/preprint_providers/list.yaml
@@ -9,7 +9,7 @@ get:
     preprints appearing first.
 
 
-    _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+    _< v2.7 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/list.yaml
+++ b/swagger-spec/preprint_providers/list.yaml
@@ -78,17 +78,9 @@ get:
                 preprints: https://api.osf.io/v2/providers/preprints/osf/preprints/
                 external_url: https://osf.io/preprints/
               attributes:
-                social_instagram: ''
                 advisory_board: ''
                 email_support: ''
-                banner_path: "/static/img/providers/preprints/cos-logo.png"
-                logo_path: "/static/img/providers/preprints/cos-logo.png"
-                subjects_acceptable: []
                 description: A scholarly commons to connect the entire research cycle
-                social_facebook: ''
-                header_text: ''
-                social_twitter: ''
-                email_contact: ''
                 example: khbvy
                 name: Open Science Framework
                 domain: 'osf.io'

--- a/swagger-spec/preprint_providers/preprints_list.yaml
+++ b/swagger-spec/preprint_providers/preprints_list.yaml
@@ -6,7 +6,7 @@ get:
     preprints appearing first.
 
 
-    _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+    _< v2.7 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/preprints_list.yaml
+++ b/swagger-spec/preprint_providers/preprints_list.yaml
@@ -6,7 +6,7 @@ get:
     preprints appearing first.
 
 
-    _< v2.7 use `preprint_providers` instead of `providers/preprints`_
+    _< v2.8 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/preprints_list.yaml
+++ b/swagger-spec/preprint_providers/preprints_list.yaml
@@ -6,6 +6,9 @@ get:
     preprints appearing first.
 
 
+    _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+
+
     #### Returns
 
 
@@ -30,7 +33,7 @@ get:
 
     You can optionally request that the response only include preprints that
     match your filters by utilizing the `filter` query parameter, e.g.
-    https://api.osf.io/v2/preprint_providers/osf/preprints/?filter[is_published]=true.
+    https://api.osf.io/v2/providers/preprints/osf/preprints/?filter[is_published]=true.
 
 
     Preprints may be filtered by their `id`, `is_published`, `date_created`,
@@ -84,7 +87,7 @@ get:
                 provider:
                   links:
                     related:
-                      href: 'https://api.osf.io/v2/preprint_providers/socarxiv/'
+                      href: 'https://api.osf.io/v2/providers/preprints/socarxiv/'
                       meta: {}
               links:
                 self: 'https://api.osf.io/v2/preprints/hqb2p/'

--- a/swagger-spec/preprint_providers/taxonomies_list.yaml
+++ b/swagger-spec/preprint_providers/taxonomies_list.yaml
@@ -8,7 +8,7 @@ get:
     preprints appearing first.
 
 
-     _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+     _< v2.7 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/preprint_providers/taxonomies_list.yaml
+++ b/swagger-spec/preprint_providers/taxonomies_list.yaml
@@ -8,6 +8,9 @@ get:
     preprints appearing first.
 
 
+     _< v2.7 use`prepint_providers` instead of `providers/preprints`_
+
+
     #### Returns
 
 
@@ -59,9 +62,9 @@ get:
               id: 584240d854be81056ceca838
           links:
             first:
-            last: https://api.osf.io/v2/preprint_providers/osf/taxonomies/?page=122
+            last: https://api.osf.io/v2/providers/preprints/osf/taxonomies/?page=122
             prev:
-            next: https://api.osf.io/v2/preprint_providers/osf/taxonomies/?page=2
+            next: https://api.osf.io/v2/providers/preprints/osf/taxonomies/?page=2
             meta:
               total: 1217
               per_page: 10

--- a/swagger-spec/preprint_providers/taxonomies_list.yaml
+++ b/swagger-spec/preprint_providers/taxonomies_list.yaml
@@ -8,7 +8,7 @@ get:
     preprints appearing first.
 
 
-     _< v2.7 use `preprint_providers` instead of `providers/preprints`_
+     _< v2.8 use `preprint_providers` instead of `providers/preprints`_
 
 
     #### Returns

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -844,6 +844,12 @@ tags:
     x-traitTag: true
     description: >-
 
+      ### v2.8
+
+
+      + Deprecate the `preprint_providers` endpoint in favor of `providers/preprints`.
+
+
       #### 2.7
 
 

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -1149,19 +1149,19 @@ paths:
   #   PREPRINT PROVIDERS   #
   ##########################
 
-  /preprint_providers/:
+  /providers/preprints/:
     $ref: 'preprint_providers/list.yaml'
 
-  /preprint_providers/{preprint_provider_id}/:
+  /providers/preprints/{preprint_provider_id}/:
     $ref: 'preprint_providers/detail.yaml'
 
-  /preprint_providers/{preprint_provider_id}/preprints/:
+  /providers/preprints/{preprint_provider_id}/preprints/:
     $ref: 'preprint_providers/preprints_list.yaml'
 
-  /preprint_providers/{preprint_provider_id}/taxonomies/:
+  /providers/preprints/{preprint_provider_id}/taxonomies/:
     $ref: 'preprint_providers/taxonomies_list.yaml'
 
-  /preprint_providers/{preprint_provider_id}/licenses/:
+  /providers/preprints/{preprint_provider_id}/licenses/:
     $ref: 'preprint_providers/licenses_list.yaml'
 
   #####################


### PR DESCRIPTION
## Purpose
Add docs for https://openscience.atlassian.net/browse/IN-150

## Changes
* Add deprecation note for `preprint_providers`
* Update urls to `providers/preprints`
* Remove previously deprecated fields that are no longer present:
```
header_text
banner_path
logo_path
email_contact
social_twitter
social_facebook
social_instagram
subjects_acceptable
```