### PR TITLE
[PLAT-836] add docs for partial registrations.

### DIFF
--- a/swagger-spec/nodes/registrations_list.yaml
+++ b/swagger-spec/nodes/registrations_list.yaml
@@ -223,6 +223,10 @@ post:
 
     &nbsp;&nbsp;&nbsp;&nbsp;`lift_embargo` (Only required when `registration_choice` is "embargo")
 
+    #### Optional
+
+    &nbsp;&nbsp;&nbsp;&nbsp;`children` (If left unspecified all children will be registered)
+
 
     #### Returns
 

--- a/swagger-spec/registrations/definition.yaml
+++ b/swagger-spec/registrations/definition.yaml
@@ -157,6 +157,12 @@ properties:
         format: date-time
         readOnly: false
         description: 'A future datetime when the registration will become public. This field should be set when "registration_choice" is set to "embargo" in the range from 2 days to 4 years.'
+      children:
+        type: array
+        items:
+          type: string
+        readOnly: false
+        description: 'A list of guids for children of nodes to be registered. All children must have parents being registered.'
   relationships:
     type: object
     title: Relationships
@@ -259,3 +265,4 @@ example:
       draft_registration: '{draft_registration_id}'
       registration_choice: embargo
       lift_embargo: '2017-05-10T20:44:03.185000'
+      children: ['fsd2s', 'dwsa2']


### PR DESCRIPTION
## Purpose 

Show people how to register a limited selection of a node's children

## Changes 

- simple doc changes

## Notes 

Might be nice to have a picture detailing the whole, no grandchildren without children thing, but my image design skill is not great.

## Ticket 

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-836

## Relevant PR
https://github.com/CenterForOpenScience/osf.io/pull/8399