### PR TITLE
[PLAT-856] Remove references to ARKs from API docs

### DIFF
--- a/swagger-spec/identifiers/definition.yaml
+++ b/swagger-spec/identifiers/definition.yaml
@@ -18,7 +18,6 @@ properties:
       category:
         type: string
         enum:
-          - ark
           - doi
         readOnly: true
         description: 'The category of the identifier'

--- a/swagger-spec/identifiers/detail.yaml
+++ b/swagger-spec/identifiers/detail.yaml
@@ -44,7 +44,7 @@ get:
             links:
               self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b45a/
             attributes:
-              category: ark
+              category: doi
               value: c7605/osf.io/73pnd
             type: identifiers
             id: 57f1641db83f6901ed94b45a

--- a/swagger-spec/identifiers/list.yaml
+++ b/swagger-spec/identifiers/list.yaml
@@ -25,7 +25,7 @@ get:
     https://api.osf.io/v2/identifiers/73pnd/identifiers/?filter[category]=doi.
 
 
-    Identifiers may be filtered by their `category` e.g `ark` or `doi`.
+    Identifiers may be filtered by their `category` e.g `doi`.
 
 
     You can learn more about advanced filtering features [here](#tag/Filtering).
@@ -66,19 +66,6 @@ get:
               value: 10.17605/OSF.IO/73PND
             type: identifiers
             id: 57f1641db83f6901ed94b459
-          - relationships:
-              referent:
-                links:
-                  related:
-                    href: https://api.osf.io/v2/nodes/73pnd/
-                    meta: {}
-            links:
-              self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b45a/
-            attributes:
-              category: ark
-              value: c7605/osf.io/73pnd
-            type: identifiers
-            id: 57f1641db83f6901ed94b45a
           links:
             first:
             last:

--- a/swagger-spec/logs/actions.yaml
+++ b/swagger-spec/logs/actions.yaml
@@ -59,8 +59,7 @@ get:
     * `updated_fields`: One or more of a Node's fields are changed
 
 
-    * `external_ids_added`: An external identifier is added to a Node (e.g.
-    DOI, ARK)
+    * `external_ids_added`: An external identifier is added to a Node (e.g. the DOI)
 
     ---
 

--- a/swagger-spec/logs/definition.yaml
+++ b/swagger-spec/logs/definition.yaml
@@ -110,7 +110,7 @@ properties:
           identifiers:
             type: string
             readOnly: true
-            description: 'Dictionary containing the DOI and ARK ID for a preprint associated with the log.'
+            description: 'Dictionary containing the DOI for a preprint associated with the log.'
           institution:
             type: string
             readOnly: true

--- a/swagger-spec/nodes/definition.yaml
+++ b/swagger-spec/nodes/definition.yaml
@@ -151,7 +151,7 @@ properties:
       identifiers:
         type: string
         readOnly: true
-        description: 'A link to the list of identifiers for this node (i.e. ARK and DOI identifiers).'
+        description: 'A link to the list of identifiers for this node (i.e. DOI identifiers).'
       license:
         type: string
         readOnly: true

--- a/swagger-spec/nodes/identifiers_list.yaml
+++ b/swagger-spec/nodes/identifiers_list.yaml
@@ -22,10 +22,10 @@ get:
 
 
     You can optionally request that the response only include nodes that match your filters by utilizing the `filter` query parameter, e.g.
-    https://api.osf.io/v2/nodes/ezcuj/identifiers/?filter[category]=ark
+    https://api.osf.io/v2/nodes/ezcuj/identifiers/?filter[category]=doi
 
 
-    Identifiers may be filtered by their `category` e.g `ark` or `doi`.
+    Identifiers may be filtered by their `category` e.g `doi`.
 
 
     You can learn more about advanced filtering features [here](#tag/Filtering).
@@ -66,19 +66,6 @@ get:
               value: 10.17605/OSF.IO/73PND
             type: identifiers
             id: 57f1641db83f6901ed94b459
-          - relationships:
-              referent:
-                links:
-                  related:
-                    href: https://api.osf.io/v2/nodes/73pnd/
-                    meta: {}
-            links:
-              self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b45a/
-            attributes:
-              category: ark
-              value: c7605/osf.io/73pnd
-            type: identifiers
-            id: 57f1641db83f6901ed94b45a
           links:
             first:
             last:

--- a/swagger-spec/registrations/definition.yaml
+++ b/swagger-spec/registrations/definition.yaml
@@ -194,7 +194,7 @@ properties:
       identifiers:
         type: string
         readOnly: true
-        description: 'A link to the list of identifiers for this registration (i.e. ARK and DOI identifiers).'
+        description: 'A link to the list of identifiers for this registration (i.e. DOI identifiers).'
       logs:
         type: string
         readOnly: true

--- a/swagger-spec/registrations/identifiers_list.yaml
+++ b/swagger-spec/registrations/identifiers_list.yaml
@@ -22,10 +22,10 @@ get:
 
 
     You can optionally request that the response only include registrations that match your filters by utilizing the `filter` query parameter, e.g.
-    https://api.osf.io/v2/registrations/wucr8/identifiers/?filter[category]=ark
+    https://api.osf.io/v2/registrations/wucr8/identifiers/?filter[category]=doi
 
 
-    Identifiers may be filtered by their `category` e.g `ark` or `doi`.
+    Identifiers may be filtered by their `category` e.g `doi`.
 
 
     You can learn more about advanced filtering features [here](#tag/Filtering).
@@ -66,19 +66,6 @@ get:
               value: 10.17605/OSF.IO/73PND
             type: identifiers
             id: 57f1641db83f6901ed94b459
-          - relationships:
-              referent:
-                links:
-                  related:
-                    href: https://api.osf.io/v2/nodes/73pnd/
-                    meta: {}
-            links:
-              self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b45a/
-            attributes:
-              category: ark
-              value: c7605/osf.io/73pnd
-            type: identifiers
-            id: 57f1641db83f6901ed94b45a
           links:
             first:
             last:

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -68,7 +68,7 @@ tags:
       data, manuscripts, or anything else associated with your research during
       the research process. Every project and file on the OSF has a permanent
       unique identifier, and every registration (a permanent, time-stamped
-      version of your projects and files) can be assigned a DOI/ARK. You can
+      version of your projects and files) can be assigned a DOI. You can
       use the OSF to measure your impact by monitoring the traffic to projects
       and files you make public. With the OSF you have full control of what
       parts of your research are public and what remains private.


### PR DESCRIPTION
## Purpose

We don't support arks anymore, so lets remove them from the docs.

## Changes

- just textual changes.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-856