### PR TITLE
Update citation detail to be consistent with branding: Open Science Framework > OSF

### DIFF
--- a/swagger-spec/nodes/citation_detail.yaml
+++ b/swagger-spec/nodes/citation_detail.yaml
@@ -32,7 +32,7 @@ get:
             id: bg4di
             type: node-citation
             attributes:
-              publisher: Open Science Framework
+              publisher: OSF
               author:
               - given: Timothy M
                 family: Errington

--- a/swagger-spec/nodes/citation_detail_definition.yaml
+++ b/swagger-spec/nodes/citation_detail_definition.yaml
@@ -26,7 +26,7 @@ properties:
       publisher:
         type: string
         readOnly: true
-        description: 'The publisher of the entity being cited. For nodes and registrations, the publisher is the ''Open Science Framework''. For preprints, the publisher is the same as the preprint provider.'
+        description: 'The publisher of the entity being cited. For nodes and registrations, the publisher is ''OSF''. For preprints, the publisher is the same as the preprint provider.'
       title:
         type: string
         readOnly: true

--- a/swagger-spec/registrations/style_detail.yaml
+++ b/swagger-spec/registrations/style_detail.yaml
@@ -38,7 +38,7 @@ get:
             id: bg4di
             type: node-citation
             attributes:
-              publisher: Open Science Framework
+              publisher: OSF
               author:
               - given: Timothy M
                 family: Errington


### PR DESCRIPTION
Citations for projects need to be consistent with our branding, so let's update project citations to say "OSF" instead of "Open Science Framework" as the publisher.

## Ticket:
https://openscience.atlassian.net/browse/PLAT-804