### PR TITLE
Add documentation for node settings GET and PATCH endpoints [PLAT-924]

### DIFF
--- a/swagger-spec/nodes/node_settings_definition.yaml
+++ b/swagger-spec/nodes/node_settings_definition.yaml
@@ -1,0 +1,66 @@
+type: object
+title: Node Settings Detail
+properties:
+  id:
+    type: string
+    readOnly: true
+    description: 'The identifier of the node that the current settings are for.'
+  type:
+    type: string
+    readOnly: false
+    description: 'The type identifier for node settings. Should be node-settings.'
+  attributes:
+    type: object
+    title: Attributes
+    readOnly: true
+    description: 'The properties of the node settings entity.'
+    properties:
+      access_requests_enabled:
+        type: string
+        readOnly: false
+        description: 'A boolean value indicating if access requests are allowed for the connected node.'
+      anyone_can_comment:
+        type: string
+        readOnly: false
+        description: 'A boolean value indicating if public comments are enabled on the connected node.'
+      anyone_can_edit_wiki:
+        type: string
+        readOnly: false
+        description: 'A boolean value indicating if public editing is enabled on the connected wiki.'
+      wiki_enabled:
+        type: string
+        readOnly: false
+        description: 'A boolean value indicating that there is a wiki connected to the associated node.'
+      redirect_link_enabled:
+        type: string
+        readOnly: false
+        description: 'A boolean value indicating that there is a redirect link activated for when a user visits the associated node.'
+      redirect_link_url:
+        type: string
+        readOnly: false
+        description: 'The redirect URL that has been configured for the associated node.'
+      redirect_link_label:
+        type: string
+        readOnly: false
+        description: 'The label for the redirect URL that has been configured for the associated node.'
+  relationships:
+    type: object
+    title: Relationships
+    readOnly: false
+    description: 'URLs to other entities or entity collections that have a relationship to the node settings entity.'
+    properties:
+      view_only_links:
+        type: string
+        readOnly: true
+        description: 'A link to the list of view only links that have been created for the connected node.'
+  links:
+    type: object
+    title: Links
+    readOnly: true
+    description: 'URLs to alternative representations of the node settings entity.'
+    properties:
+      self:
+        type: string
+        format: URL
+        readOnly: true
+        description: 'A link to the node settings entity.'

--- a/swagger-spec/nodes/node_settings_detail.yaml
+++ b/swagger-spec/nodes/node_settings_detail.yaml
@@ -1,0 +1,116 @@
+# /nodes/{node_id}/settings/
+get:
+  summary: Retrieve node settings
+  description: >-
+    Retrieves the details of settings related to the node.
+
+
+    #### Returns
+
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    node settings, if the request is successful.
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#tag/Errors-and-Error-Codes)
+    to understand why this request may have failed.
+
+
+    #### Permissions
+
+
+    Settings for a node are readable by users that are contributors on the node. Most fields are writeable only by users that are administrators on the node.
+    The fields for determining redirect links are writable by a contributor who has read/write permissions on the node.
+
+
+  parameters:
+
+    - in: path
+      type: string
+      name: node_id
+      required: true
+      description: 'The unique identifier of the node.'
+
+
+  tags:
+    - Nodes
+  operationId: node_settings_detail
+  x-response-schema: 'Node Settings'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: 'node_settings_definition.yaml'
+      examples:
+        application/json:
+          data:
+            relationships:
+              view_only_links:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/nodes/ezcuj/view_only_links/
+                    meta: {}
+            links:
+              self: https://api.osf.io/v2/nodes/ezcuj/settings/
+            attributes:
+              redirect_link_enabled: true
+              redirect_link_url: "https://reproducibility.osf.io/"
+              access_requests_enabled: false
+              redirect_link_label: "Published Study"
+              anyone_can_comment: true
+              wiki_enabled: true
+              anyone_can_edit_wiki: false
+            type: node-settings
+            id: ezcuj
+
+patch:
+  summary: Update node settings
+  description: >-
+    Updates the details of settings related to the node.
+
+
+    #### Returns
+
+
+    Returns a JSON object with a `data` key containing the updated representation of the requested
+    node settings, if the request is successful.
+
+
+    If the request is unsuccessful, an `errors` key containing
+    information about the failure will be returned. Refer to the [list of error codes](#tag/Errors-and-Error-Codes)
+    to understand why this request may have failed.
+
+
+    #### Permissions
+
+
+    Most fields on the node settings entity are writeable only by users that are administrators on the node.
+    The fields for determining redirect links are writable by a contributor who has read/write permissions on the node.
+
+
+  parameters:
+
+    - in: path
+      type: string
+      name: node_id
+      required: true
+      description: 'The unique identifier of the node.'
+
+
+  tags:
+    - Nodes
+  operationId: node_settings_detail
+  x-response-schema: 'Node Settings'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: 'node_settings_definition.yaml'
+        example:
+          data:
+            type: node-settings
+            id: '{node_id}'
+            attributes:
+              wiki_enabled: false
+              access_requests_enabled: true

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -1130,6 +1130,9 @@ paths:
   /nodes/{node_id}/wikis/:
     $ref: 'nodes/wikis_list.yaml'
 
+  /nodes/{node_id}/settings/:
+    $ref: 'nodes/node_settings_detail.yaml'
+
   #/nodes/{node_id}/relationships/institutions:
   #  $ref: 'nodes/institutions_relationships.yaml'
 


### PR DESCRIPTION
Add documentation for NodeSettings API v2 endpoints.

Related OSF PR: https://github.com/CenterForOpenScience/osf.io/pull/8536
Related ticket: http://openscience.atlassian.net/browse/PLAT-924

## Retrieve details
![screen shot 2018-07-13 at 10 23 32 am](https://user-images.githubusercontent.com/801594/42696789-3a220e02-8687-11e8-8c03-84a843158b10.png)

## Update Settings
![screen shot 2018-07-13 at 10 23 49 am](https://user-images.githubusercontent.com/801594/42696840-63745cc4-8687-11e8-8c1e-bef8e3bfca04.png)

