### PR TITLE
[PLAT-990] Remove node from list of filterable attributes

### DIFF
--- a/swagger-spec/nodes/files_list.yaml
+++ b/swagger-spec/nodes/files_list.yaml
@@ -27,7 +27,7 @@ get:
     https://api.osf.io/v2/nodes/ezcuj/files/osfstorage/?filter[kind]=file
 
 
-    Node files may be filtered by `id`, `name`, `node`, `kind`, `path`, `provider`, `size`, and `last_touched`.
+    Node files may be filtered by `id`, `name`, `kind`, `path`, `provider`, `size`, and `last_touched`.
 
 
     You can learn more about advanced filtering features [here](#tag/Filtering).

--- a/swagger-spec/registrations/files_list.yaml
+++ b/swagger-spec/registrations/files_list.yaml
@@ -27,7 +27,7 @@ get:
     https://api.osf.io/v2/registrations/wucr8/files/osfstorage/?filter[kind]=file
 
 
-    Files may be filtered by `id`, `name`, `node`, `kind`, `path`, `provider`, `size`, and `last_touched`.
+    Files may be filtered by `id`, `name`, `kind`, `path`, `provider`, `size`, and `last_touched`.
 
 
     You can learn more about advanced filtering features [here](#tag/Filtering).


### PR DESCRIPTION
## Purpose 
Filtering file on nodes was redundant  and bugged, so we removed it. This fix changes the docs to account for the change.

## Changes

- Simple textual changes

## Side Effects 

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-990