### PR TITLE
NPD docs + Draft Registration docs correction [PLAT-555] [PLAT-1001]

### DIFF
--- a/swagger-spec/logs/actions.yaml
+++ b/swagger-spec/logs/actions.yaml
@@ -207,13 +207,13 @@ get:
     ---
 
 
-    * `preprint_initiated`: A preprint is made from the node
+    * `preprint_initiated`: A preprint is made from the node (deprecated log, preprints are no longer made from nodes)
 
 
-    * `preprint_license_updated`: A license is added or updated to the preprint
+    * `preprint_license_updated`: A license is added or updated to the preprint (deprecated log, preprint actions are no longer logged on the node)
 
 
-    * `preprint_file_updated`: The primary file of a preprint is updated
+    * `preprint_file_updated`: The primary file of a preprint is updated (deprecated log, this action is now logged on the preprint)
 
 
   responses:

--- a/swagger-spec/nodes/definition.yaml
+++ b/swagger-spec/nodes/definition.yaml
@@ -86,7 +86,7 @@ properties:
       preprint:
         type: boolean
         readOnly: true
-        description: 'Whether or not a preprint has been created from this node, or if this node was created for a preprint.'
+        description: 'Whether or not the node contains supplemental material for a preprint.'
       public:
         type: boolean
         readOnly: false
@@ -175,7 +175,7 @@ properties:
       preprints:
         type: string
         readOnly: true
-        description: 'A link to the list of preprints that this node relates to.'
+        description: 'A link to the list of preprints for which this node contains supplemental materials.'
       registrations:
         type: string
         readOnly: true

--- a/swagger-spec/nodes/draft_registration_definition.yaml
+++ b/swagger-spec/nodes/draft_registration_definition.yaml
@@ -25,7 +25,6 @@ properties:
     required:
       - datetime_initiated
       - datetime_updated
-      - registration_supplement
     properties:
       datetime_initiated:
         type: string
@@ -41,15 +40,11 @@ properties:
         type: string
         readOnly: false
         description: 'A dictionary of question IDs and responses from the registration schema.'
-      registration_supplement:
-        type: string
-        readOnly: false
-        description: 'The ID of an active registration schema that this registration will conform to.'
 
   relationships:
     type: object
     title: Relationships
-    readOnly: true
+    readOnly: false
     required:
       - branched_from
       - initiator
@@ -66,7 +61,7 @@ properties:
         description: 'A link to the user who initiated the draft registration.'
       registration_schema:
         type: string
-        readOnly: true
+        readOnly: false
         description: 'A link to the detailed registration schema that this draft conforms to.'
 
   links:
@@ -86,6 +81,8 @@ properties:
 example:
   data:
     type: 'draft_registrations'
-    attributes:
-      registration_supplement: '{schema_id}'
-
+    relationships:
+      registration_schema:
+          data:
+              id: '{schema_id}'
+              type: registration_schemas

--- a/swagger-spec/nodes/draft_registration_detail.yaml
+++ b/swagger-spec/nodes/draft_registration_detail.yaml
@@ -57,7 +57,6 @@ get:
               datetime_initiated: ''
               datetime_updated: ''
               registration_metadata: {}
-              registration_supplement: ''
             relationships:
               branched_from:
                 links:

--- a/swagger-spec/nodes/draft_registration_detail_definition.yaml
+++ b/swagger-spec/nodes/draft_registration_detail_definition.yaml
@@ -21,21 +21,17 @@ properties:
     readOnly: false
     description: 'The properties of the draft registration entity.'
     required:
-      - registration_supplement
+      - registration_schema
     properties:
       registration_metadata:
         type: string
         readOnly: false
         description: 'A dictionary of question IDs and responses from the registration schema.'
-      registration_supplement:
-        type: string
-        readOnly: false
-        description: 'The ID of an active registration schema that this registration will conform to.'
 
 
 example:
   data:
-    id: '{registration_supplement_id}'
+    id: '{draft_registration_id}'
     type: 'draft_registrations'
     attributes:
       registration_metadata:

--- a/swagger-spec/nodes/draft_registrations_list.yaml
+++ b/swagger-spec/nodes/draft_registrations_list.yaml
@@ -58,7 +58,6 @@ get:
               datetime_initiated: ''
               datetime_updated: ''
               registration_metadata: {}
-              registration_supplement: ''
             relationships:
               branched_from:
                 links:
@@ -113,7 +112,7 @@ post:
     Required fields for creating a draft registration include:
 
 
-    &nbsp;&nbsp;&nbsp;&nbsp;`registration_supplement`
+    &nbsp;&nbsp;&nbsp;&nbsp;`registration_schema`
 
     #### Returns
 

--- a/swagger-spec/nodes/preprints_list.yaml
+++ b/swagger-spec/nodes/preprints_list.yaml
@@ -1,7 +1,7 @@
 get:
   summary: List all preprints
   description: >-
-    A paginated list of preprints related to a given node.
+    A paginated list of preprints for which the given node contains supplemental materials.
     The returned preprints are sorted by their creation date, with the most recent
     preprints appearing first.
 

--- a/swagger-spec/preprints/definition.yaml
+++ b/swagger-spec/preprints/definition.yaml
@@ -17,50 +17,110 @@ properties:
     title: Attributes
     readOnly: false
     description: 'The properties of the preprint entity.'
+    required:
+      - title
     properties:
-      date_created:
+      date_last_transitioned:
+          type: string
+          format: date-time
+          readOnly: true
+          description: 'The time at which the preprint''s reviews state was last changed. For example, the time at which a preprint''s reviews state was moved from "pending" to "accepted".'
+      doi:
         type: string
-        format: date-time
+        readOnly: false
+        description: 'The DOI of the associated journal article, as entered by the user, if the preprint is published.'
+      description:
+        type: string
+        readOnly: false
+        description: 'The description of the preprint'
+      title:
+        type: string
+        readOnly: false
+        description: 'The title of the preprint'
+      reviews_state:
+        type: string
         readOnly: true
-        description: 'The time at which the preprint was created, as an iso8601 formatted timestamp.'
+        description: 'The preprint''s review status, e.g. pending, accepted, rejected, etc.'
+      license_record:
+        type: string
+        readOnly: false
+        description: 'The metadata (copyright year and holder) associated with a license, required for certain licenses.'
       date_modified:
         type: string
         format: date-time
         readOnly: true
         description: 'The time at which the preprint was last modified, as an iso8601 formatted timestamp.'
+      original_publication_date:
+        type: string
+        format: date-time
+        readOnly: false
+        description: 'User-entered, the date when the preprint was originally published'
+      date_withdrawn:
+        type: string
+        format: date-time
+        readOnly: true
+        description: 'The date when the preprint was withdrawn'
+      preprint_doi_created:
+        type: string
+        format: date-time
+        readOnly: true
+        description: 'The date when the doi was minted for the preprint'
+      is_preprint_orphan:
+        type: boolean
+        readOnly: true
+        description: 'Whether or not the preprint is orphaned. A preprint can be orphaned if it''s primary file was removed from the preprint node. This field may be deprecated in future versions.'
       date_published:
         type: string
         format: date-time
         readOnly: true
         description: 'The time at which the preprint was published, as an iso8601 formatted timestamp.'
-      doi:
-        type: string
-        readOnly: false
-        description: 'The DOI of the associated journal article, as entered by the user, if the preprint is published.'
-      is_preprint_orphan:
-        type: boolean
-        readOnly: true
-        description: 'Whether or not the preprint is orphaned. A preprint can be orphaned if it''s primary file was removed from the preprint node. This field may be deprecated in future versions.'
-      license_record:
-        type: string
-        readOnly: false
-        description: 'The metadata (copyright year and holder) associated with a license, required for certain licenses.'
       subjects:
         type: array
         items:
           type: string
         readOnly: false
         description: 'A nested array structure that describe subjects related to the preprint, in the BePress taxonomy. Each dictionary contains the text and ID of a subject.'
+      date_created:
+        type: string
+        format: date-time
+        readOnly: true
+        description: 'The time at which the preprint was created, as an iso8601 formatted timestamp.'
+      is_published:
+         type: boolean
+         readOnly: false
+         description: 'Whether or not a preprint is published'
+      public:
+         type: boolean
+         readOnly: false
+         description: 'Whether a preprint has been marked as public.  This is not a user-facing setting.  Legacy preprints or spammy preprints may be marked as private'
+      tags:
+          type: array
+          items:
+            type: string
+          readOnly: false
+          description: 'A list of the preprint''s tags.'
+      current_user_permissions:
+          type: array
+          items:
+             type: string
+          readOnly: true
+          description: 'The logged-in user''s permissions to the preprint'
   relationships:
     type: object
     title: Relationships
     readOnly: false
     description: 'URLs to other entities or entity collections that have a relationship to the preprint entity.'
     required:
-      - node
-      - primary_file
       - provider
     properties:
+      files:
+        type: string
+        readOnly: true
+        description: 'A relationship to the storage providers to the preprint - in this case, preprints are restricted to having just the OsfStorage provider.'
+      contributors:
+        type: string
+        readOnly: true
+        description: 'A relationship to the preprint authors'
       citation:
         type: string
         readOnly: true
@@ -76,7 +136,7 @@ properties:
       node:
         type: string
         readOnly: false
-        description: 'A relationship to the node that was created for the preprint, or from which the preprint was created.'
+        description: 'A relationship to the project containing supplemental materials for the preprints.'
       primary_file:
         type: string
         readOnly: false
@@ -113,16 +173,9 @@ properties:
         description: 'A link to the detail page for the preprint.'
 example:
   data:
-    attributes: {}
+    attributes:
+      title: 'A study of economics'
     relationships:
-      node:
-        data:
-          type: nodes
-          id: '{node_id}'
-      primary_file:
-        data:
-          type: primary_files
-          id: '{primary_file_id}'
       provider:
         data:
           type: providers

--- a/swagger-spec/preprints/detail.yaml
+++ b/swagger-spec/preprints/detail.yaml
@@ -40,6 +40,19 @@ get:
                   related:
                     href: https://api.osf.io/v2/nodes/bnzx5/
                     meta: {}
+                  self:
+                    href: 'https://api.osf.io/v2/preprints/khbvy/relationships/node/'
+                    meta: {}
+              files:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/preprints/khbvy/files/
+                    meta: {}
+              contributors:
+                links:
+                related:
+                  href: https://api.osf.io/v2/preprints/khbvy/contributors/
+                  meta: {}
               citation:
                 links:
                   related:
@@ -55,10 +68,25 @@ get:
                   related:
                     href: https://api.osf.io/v2/files/57c44b1e594d90004a421ab1/
                     meta: {}
+              license:
+                links:
+                  related:
+                    href: 'https://api.osf.io/v2/licenses/563c1cf88c5e4a3877f9e96a/'
+                    meta: {}
               provider:
                 links:
                   related:
                     href: https://api.osf.io/v2/preprint_providers/osf/
+                    meta: {}
+              requests:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/preprints/khbvy/requests/
+                    meta: {}
+              review_actions:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/preprints/khbvy/review_actions/
                     meta: {}
             links:
               self: https://api.osf.io/v2/preprints/khbvy/
@@ -66,9 +94,18 @@ get:
               doi: https://dx.doi.org/10.1371/journal.pbio.1002456
               preprint_doi: https://dx.doi.org/10.5072/FK2OSF.IO/KHBVY
             attributes:
+              date_last_transitioned: '2018-10-15T13:44:09.478243'
               doi: 10.1371/journal.pbio.1002456
+              description: 'A study of Kale'
+              title: 'Kale contains vitamins'
+              reviews_state: 'accepted'
               license_record:
+                 copyright_holders: []
+                 year: '2017'
               date_modified: '2016-08-29T14:53:51.185000'
+              original_publication_date: null
+              date_withdrawn: null
+              preprint_doi_created: null
               is_preprint_orphan: false
               date_published: '2016-08-29T14:53:51.185000'
               subjects:
@@ -94,6 +131,13 @@ get:
                   id: 584240da54be81056cecac68
               date_created: '2016-08-29T14:53:51.185000'
               is_published: true
+              public: true
+              tags:
+              - vitamin a
+              - vitamin k
+              current_user_permissions:
+              - read
+              - write
             type: preprints
             id: khbvy
 
@@ -102,6 +146,21 @@ patch:
   description: >-
     Updates the specified preprint by setting the values of the parameters passed.
     Any parameters not provided will be left unchanged.
+
+
+    The file that you either uploaded to the preprint or copied from an OSF project to the preprint
+    will need to be set as the primary file before the preprint can be published.
+
+
+    To remove a supplemental project from a preprint will be a separate PATCH request to the node self relationship
+    link.
+
+
+    PATCH /v2/preprints/<preprint_id>/relationships/node/
+
+
+    {data: null}
+
 
     #### Returns
 
@@ -128,11 +187,17 @@ patch:
             id: "{preprint_id}"
             attributes:
               doi: "{doi}"
+              is_published: true
+              subjects: [["<subject_id>"]]
             relationships:
               primary_file:
                 data:
                   type: "primary_files"
                   id: "{file_id}"
+              node:
+                data:
+                  type: "nodes"
+                  id: "{node_id}"
 
   tags:
     - Preprints

--- a/swagger-spec/preprints/list.yaml
+++ b/swagger-spec/preprints/list.yaml
@@ -58,6 +58,19 @@ get:
                     related:
                       href: 'https://api.osf.io/v2/nodes/5xuck/'
                       meta: {}
+                    self:
+                      href: 'https://api.osf.io/v2/preprints/hqb2p/relationships/node/'
+                      meta: {}
+                files:
+                  links:
+                    related:
+                      href: 'https://api.osf.io/v2/preprints/hqb2p/files/'
+                      meta: {}
+                contributors:
+                  links:
+                    related:
+                      href: 'https://api.osf.io/v2/preprints/hqb2p/contributors/'
+                      meta: {}
                 citation:
                   links:
                     related:
@@ -83,16 +96,33 @@ get:
                     related:
                       href: 'https://api.osf.io/v2/preprint_providers/socarxiv/'
                       meta: {}
+                requests:
+                  links:
+                    related:
+                      href: 'https://api.osf.io/v2/preprints/hqb2p/requests/'
+                      meta: {}
+                review_actions:
+                    links:
+                        related:
+                            href: 'https://api.osf.io/v2/preprints/hqb2p/review_actions/'
+                            meta: {}
               links:
                 self: 'https://api.osf.io/v2/preprints/hqb2p/'
                 html: 'https://osf.io/preprints/socarxiv/hqb2p/'
                 preprint_doi: 'https://dx.doi.org/10.5072/FK2OSF.IO/HQB2P'
               attributes:
+                date_last_transitioned: '2018-10-15T13:44:09.478243'
                 doi: null
+                description: 'A tale of two cities'
+                title: 'A Study of Urban versus Rural'
+                reviews_state: 'accepted'
                 license_record:
                   copyright_holders: []
                   year: '2017'
                 date_modified: '2017-02-03T06:19:00.158000'
+                original_publication_date: null
+                date_withdrawn: null
+                preprint_doi_created: null
                 is_preprint_orphan: false
                 date_published: '2017-02-03T06:18:59.788000'
                 subjects:
@@ -102,6 +132,13 @@ get:
                       id: 584240da54be81056cecac1a
                 date_created: '2017-02-03T06:16:57.129000'
                 is_published: true
+                public: true
+                tags:
+                - city
+                - country
+                - suburb
+                current_user_permissions:
+                - read
               type: preprints
               id: hqb2p
           links:
@@ -116,7 +153,36 @@ get:
 post:
   summary: Create a preprint
   description: >-
-    Creates a new preprint.
+    Creates a new preprint.  Initial request to start the preprint requires a title and a provider.
+
+
+    After you've created the preprint, you will need to upload a file to the preprint
+    or copy a file from an existing OSF project, which will be a waterbutler request.
+
+
+    To upload a new file to the preprint -
+
+        1. Make a request to the preprint files' relationship to get the preprint's upload link.
+        2. Issue a PUT request to the preprint's upload link
+
+        curl -X "PUT" "https://files.us.osf.io/v1/resources/<preprint_id>/providers/osfstorage/?kind=file&name=my_preprint_file.txt" \
+            --
+            -H "Authorization: Bearer your-token-goes-here" \
+            -H "Content-Type: text/plain" \
+            -d "Contents of my preprint file go here"
+
+    To copy an existing file from a project to your preprint -
+
+        1. Make a request to the node file's list endpoint GET http://api.osf.io/v2/nodes/node_id/files/osfstorage/
+        2. Locate the "move" relationship link for the file you wish to copy from the node to the preprint
+        3. Issue a POST request to the file's move link, where the resource is the preprint id, the action is copy, and the provider is osfstorage.
+
+        curl -X "POST" "https://files.us.osf.io/v1/resources/<node_id>/providers/osfstorage/<file_id>" \
+            --
+            -H "Authorization: Bearer your-token-goes-here " \
+            -H "Content-Type: application/json" \
+            -d '{"action": "copy", "path": "/", "resource": "<preprint_id>", "provider": "osfstorage", "conflict": "replace"}'
+
 
     #### Returns
 

--- a/swagger-spec/users/preprints_list.yaml
+++ b/swagger-spec/users/preprints_list.yaml
@@ -54,66 +54,117 @@ get:
         application/json:
           data:
           - relationships:
-              node:
-                links:
-                  related:
-                    href: https://api.osf.io/v2/nodes/bnzx5/
-                    meta: {}
-              citation:
-                links:
-                  related:
-                    href: https://api.osf.io/v2/preprints/khbvy/citation/
-                    meta: {}
-              primary_file:
-                links:
-                  related:
-                    href: https://api.osf.io/v2/files/57c44b1e594d90004a421ab1/
-                    meta: {}
-              provider:
-                links:
-                  related:
-                    href: https://api.osf.io/v2/preprint_providers/osf/
-                    meta: {}
-            links:
-              self: https://api.osf.io/v2/preprints/khbvy/
-              html: https://osf.io/khbvy/
-              doi: https://dx.doi.org/10.1371/journal.pbio.1002456
-            attributes:
-              doi: 10.1371/journal.pbio.1002456
-              license_record:
-              date_modified: '2016-08-29T14:53:51.185000'
-              is_preprint_orphan: false
-              date_published: '2016-08-29T14:53:51.185000'
-              subjects:
-              - - text: Social and Behavioral Sciences
-                  id: 584240da54be81056cecac48
-                - text: Public Affairs, Public Policy and Public Administration
-                  id: 584240da54be81056cecaab8
-                - text: Science and Technology Policy
-                  id: 584240d954be81056cecaa10
-              - - text: Social and Behavioral Sciences
-                  id: 584240da54be81056cecac48
-                - text: Library and Information Science
-                  id: 584240da54be81056cecab33
-                - text: Scholarly Publishing
-                  id: 584240db54be81056cecacd2
-              - - text: Social and Behavioral Sciences
-                  id: 584240da54be81056cecac48
-                - text: Psychology
-                  id: 584240da54be81056cecac68
-              - - text: Social and Behavioral Sciences
-                  id: 584240da54be81056cecac48
-                - text: Psychology
-                  id: 584240da54be81056cecac68
-              date_created: '2016-08-29T14:53:51.185000'
-              is_published: true
-            type: preprints
-            id: khbvy
+            node:
+              links:
+                related:
+                  href: https://api.osf.io/v2/nodes/bnzx5/
+                  meta: {}
+                self:
+                  href: 'https://api.osf.io/v2/preprints/khbvy/relationships/node/'
+                  meta: {}
+            files:
+              links:
+                related:
+                  href: https://api.osf.io/v2/preprints/khbvy/files/
+                  meta: {}
+            contributors:
+              links:
+              related:
+                href: https://api.osf.io/v2/preprints/khbvy/contributors/
+                meta: {}
+            citation:
+              links:
+                related:
+                  href: https://api.osf.io/v2/preprints/khbvy/citation/
+                  meta: {}
+            identifiers:
+              links:
+                related:
+                  href: https://api.osf.io/v2/preprints/khbvy/identifiers/
+                  meta: {}
+            primary_file:
+              links:
+                related:
+                  href: https://api.osf.io/v2/files/57c44b1e594d90004a421ab1/
+                  meta: {}
+            license:
+              links:
+                related:
+                  href: 'https://api.osf.io/v2/licenses/563c1cf88c5e4a3877f9e96a/'
+                  meta: {}
+            provider:
+              links:
+                related:
+                  href: https://api.osf.io/v2/preprint_providers/osf/
+                  meta: {}
+            requests:
+              links:
+                related:
+                  href: https://api.osf.io/v2/preprints/khbvy/requests/
+                  meta: {}
+            review_actions:
+              links:
+                related:
+                  href: https://api.osf.io/v2/preprints/khbvy/review_actions/
+                  meta: {}
           links:
-            first:
-            last:
-            prev:
-            next:
-            meta:
-              total: 4
-              per_page: 10
+            self: https://api.osf.io/v2/preprints/khbvy/
+            html: https://osf.io/khbvy/
+            doi: https://dx.doi.org/10.1371/journal.pbio.1002456
+            preprint_doi: https://dx.doi.org/10.5072/FK2OSF.IO/KHBVY
+          attributes:
+            date_last_transitioned: '2018-10-15T13:44:09.478243'
+            doi: 10.1371/journal.pbio.1002456
+            description: 'A study of Kale'
+            title: 'Kale contains vitamins'
+            reviews_state: 'accepted'
+            license_record:
+               copyright_holders: []
+               year: '2017'
+            date_modified: '2016-08-29T14:53:51.185000'
+            original_publication_date: null
+            date_withdrawn: null
+            preprint_doi_created: null
+            is_preprint_orphan: false
+            date_published: '2016-08-29T14:53:51.185000'
+            subjects:
+            - - text: Social and Behavioral Sciences
+                id: 584240da54be81056cecac48
+              - text: Public Affairs, Public Policy and Public Administration
+                id: 584240da54be81056cecaab8
+              - text: Science and Technology Policy
+                id: 584240d954be81056cecaa10
+            - - text: Social and Behavioral Sciences
+                id: 584240da54be81056cecac48
+              - text: Library and Information Science
+                id: 584240da54be81056cecab33
+              - text: Scholarly Publishing
+                id: 584240db54be81056cecacd2
+            - - text: Social and Behavioral Sciences
+                id: 584240da54be81056cecac48
+              - text: Psychology
+                id: 584240da54be81056cecac68
+            - - text: Social and Behavioral Sciences
+                id: 584240da54be81056cecac48
+              - text: Psychology
+                id: 584240da54be81056cecac68
+            date_created: '2016-08-29T14:53:51.185000'
+            is_published: true
+            public: true
+            tags:
+            - vitamin a
+            - vitamin k
+            current_user_permissions:
+            - read
+            - write
+          type: preprints
+          id: khbvy
+
+        links:
+          first:
+          last:
+          prev:
+          next:
+          meta:
+            total: 4
+            per_page: 10


### PR DESCRIPTION
# Purpose
Update docs to reflect preprints' removal of the dependency on a node. While I'm here, adding to docs for Node Draft Registrations - registration schema is set via relationships instead of attributes.

# Changes
- Definition of a preprint updated, preprint serializer has many more fields that were previously stored on the node
- Preprint Create/Update modified to reflect changes in the process, WB file requests also detailed
- Preprint List, User Preprints, Node Preprints definitions modified
- Preprint node relationship, preprint attribute modified to reflect this is whether projects contain supplemental material for a preprint, rather than this was the node created for a preprint.

- Draft Registration creation information updated, as well as draft registration required fields
### Create a preprint
<img width="1012" alt="screen shot 2018-10-15 at 2 30 25 pm" src="https://user-images.githubusercontent.com/9755598/46974099-ae1bfe80-d088-11e8-8b8f-f4cc14e3eb9e.png">

### Update a preprint
<img width="1021" alt="screen shot 2018-10-15 at 2 34 56 pm" src="https://user-images.githubusercontent.com/9755598/46974179-ea4f5f00-d088-11e8-8116-1f2058d61fa4.png">


### Preprint attributes
<img width="599" alt="screen shot 2018-10-15 at 2 33 23 pm" src="https://user-images.githubusercontent.com/9755598/46974112-b7a56680-d088-11e8-9919-9a91a8e487c1.png">

### Preprint relationships
<img width="670" alt="screen shot 2018-10-15 at 2 33 44 pm" src="https://user-images.githubusercontent.com/9755598/46974118-bb38ed80-d088-11e8-9327-b66b0080aa2e.png">

### Preprints List
<img width="1007" alt="screen shot 2018-10-15 at 2 34 16 pm" src="https://user-images.githubusercontent.com/9755598/46974150-d4da3500-d088-11e8-986f-6937c83873e4.png">
<img width="1009" alt="screen shot 2018-10-15 at 2 34 23 pm" src="https://user-images.githubusercontent.com/9755598/46974155-d6a3f880-d088-11e8-9321-dba38274cbad.png">

### Preprint Detail
<img width="1036" alt="screen shot 2018-10-15 at 2 34 34 pm" src="https://user-images.githubusercontent.com/9755598/46974163-ddcb0680-d088-11e8-8e78-adebaa5aeed8.png">
<img width="1027" alt="screen shot 2018-10-15 at 2 34 38 pm" src="https://user-images.githubusercontent.com/9755598/46974172-e28fba80-d088-11e8-8850-0bf1506ef661.png">

### Node preprint attributes
<img width="664" alt="screen shot 2018-10-15 at 2 46 31 pm" src="https://user-images.githubusercontent.com/9755598/46974270-2e426400-d089-11e8-9b72-1267cf0e0440.png">

### Node preprints relationships
<img width="657" alt="screen shot 2018-10-15 at 2 46 44 pm" src="https://user-images.githubusercontent.com/9755598/46976286-abbca300-d08e-11e8-942f-929679021fcb.png">



### Draft Registration Create
<img width="996" alt="screen shot 2018-10-15 at 3 17 31 pm" src="https://user-images.githubusercontent.com/9755598/46976131-3650d280-d08e-11e8-9dc6-2f4c9d51b138.png">

### Registration schema relationship required on creation, not registration_supplement (which has been removed)
<img width="669" alt="screen shot 2018-10-15 at 3 17 38 pm" src="https://user-images.githubusercontent.com/9755598/46976150-44065800-d08e-11e8-8c27-5b871e0050b6.png">

### Example draft registration detail - registration supplement is no longer an attribute
<img width="996" alt="screen shot 2018-10-15 at 3 18 38 pm" src="https://user-images.githubusercontent.com/9755598/46976175-51bbdd80-d08e-11e8-989a-1d53800f00e8.png">





# Ticket
https://openscience.atlassian.net/projects/PLAT/issues/PLAT-555