### PR TITLE
Add details about returning a secret for enabling two factor authentication

### DIFF
--- a/swagger-spec/users/settings_detail.yaml
+++ b/swagger-spec/users/settings_detail.yaml
@@ -70,6 +70,10 @@ patch:
     node, if the request is successful.
 
 
+    If the update request enables two-factor authentication with the `two_factor_enabled` key, the response will include the `secret` needed to
+    complete two-factor authentication. This key will only be returned if the two-factor authentication is enabled, but not yet confirmed.
+
+
     If the request is unsuccessful, an `errors` key containing information about the failure will be returned.
     Refer to the [list of error codes](#tag/Errors-and-Error-Codes) to understand why this request may have failed.
 


### PR DESCRIPTION
Add paragraph in `return` section detailing when `secret` will be included in response from `PUT` or `PATCH` requests.

<img width="531" alt="screen shot 2018-12-19 at 1 31 50 pm" src="https://user-images.githubusercontent.com/801594/50240379-a59ab980-0392-11e9-8729-72488453e95a.png">

Ticket: https://openscience.atlassian.net/browse/PLAT-1280