### PR TITLE
Add tags to node request sample [PLAT-591]

### DIFF
--- a/swagger-spec/nodes/definition.yaml
+++ b/swagger-spec/nodes/definition.yaml
@@ -224,3 +224,4 @@ example:
     attributes:
       title: 'An Excellent Project Title'
       category: 'software'
+      tags: ['some', 'tags']


### PR DESCRIPTION
Add an example of adding tags when creating a node.

Since tags are a normal attribute and they are already included in the update payload example, I didn't add any more tag-specific information in any descriptions as it will be the same for any attribute on any object.

<img width="461" alt="screen shot 2019-01-09 at 3 51 58 pm" src="https://user-images.githubusercontent.com/801594/50927876-10399500-1427-11e9-89f3-5367d97d9259.png">

https://openscience.atlassian.net/browse/PLAT-591
