### PR TITLE
Feature/Improve Wiki Docs [PLAT-1306]

### DIFF
--- a/swagger-spec/nodes/wikis_list.yaml
+++ b/swagger-spec/nodes/wikis_list.yaml
@@ -104,13 +104,17 @@ post:
   description: >-
     Creates a new wiki page on the given node.
 
-
     `name` is the only required field when creating a new wiki page.
     The `content` of the wiki page may optionally be included.
 
 
-    Returns a JSON object with a `data` key containing the representation of the created wiki, if the request is successful.
+    This POST request creates a wiki page, and then creates a first version for the wiki -
+    adding your content to the first version. For subsequent updates to this wiki page,
+    POST to the versions relationship.  This will create new versions of this wiki.
+    For more information, see [Update a wiki](#operation/wiki_versions_create).
 
+
+    Returns a JSON object with a `data` key containing the representation of the created wiki, if the request is successful.
 
     If the request is unsuccessful, an `errors` key containing information about the failure will be returned.
     Refer to the [list of error codes](#tag/Errors-and-Error-Codes) to understand why this request may have failed.

--- a/swagger-spec/wikis/definition.yaml
+++ b/swagger-spec/wikis/definition.yaml
@@ -70,11 +70,7 @@ properties:
     title: Relationships
     readOnly: false
     description: 'URLs to other entities or entity collections that have a relationship to the wiki.'
-    required:
-      - node
-      - user
-      - comments
-      - versions
+
     properties:
       node:
         type: string

--- a/swagger-spec/wikis/versions_list.yaml
+++ b/swagger-spec/wikis/versions_list.yaml
@@ -89,6 +89,9 @@ post:
     `content` is the only required field when updating a wiki page.
 
 
+    For information on creating a wiki for a node, see [Create a wiki](#operation/nodes_wikis_list_create).
+
+
     Returns a JSON object with a `data` key containing the representation of the created wiki version, if the request is successful.
 
 


### PR DESCRIPTION
# Purpose

We have pretty thorough API v2 wiki docs, but because there are different endpoints involved (node endpoints and wiki endpoints), it can be difficult to find the pieces necessary.

# Changes
- Remove wiki relationship links as `required` fields in request - this isn't correct.
- Link the different sections of wiki docs together
<img width="993" alt="screen shot 2019-01-12 at 9 49 25 am" src="https://user-images.githubusercontent.com/9755598/51075358-e616eb80-164f-11e9-9c99-3850a0996333.png">
<img width="995" alt="screen shot 2019-01-12 at 9 50 34 am" src="https://user-images.githubusercontent.com/9755598/51075360-e7481880-164f-11e9-8b4e-df943e6a71e8.png">

