### PR TITLE
Feature/APIv2 Editable Registration Fields and Minting DOI docs [EMB-567][EMB-570]

### DIFF
--- a/swagger-spec/identifiers/definition.yaml
+++ b/swagger-spec/identifiers/definition.yaml
@@ -12,14 +12,14 @@ properties:
   attributes:
     type: object
     title: Attributes
-    readOnly: true
+    readOnly: false
     description: 'The properties of the identifier entity.'
     properties:
       category:
         type: string
         enum:
           - doi
-        readOnly: true
+        readOnly: false
         description: 'The category of the identifier'
       value:
         type: string

--- a/swagger-spec/nodes/identifiers_list.yaml
+++ b/swagger-spec/nodes/identifiers_list.yaml
@@ -74,3 +74,72 @@ get:
             meta:
               total: 2
               per_page: 10
+
+
+post:
+  summary: Create identifiers
+  description: >-
+    Create an identifier for a given node - can only mint DOI's at this time.  Send
+    a POST request with a `category` attribute with a value of 'doi'.
+
+
+    #### Returns
+
+
+    Returns a JSON object containing `data` and `links` keys.
+
+
+    The `data` key contains the created identifier object.
+
+  parameters:
+    - in: path
+      name: node_id
+      type: string
+      required: true
+      description: 'The unique identifier of the node.'
+    - in: body
+      name: body
+      required: true
+      schema:
+        type: object
+        example:
+          data:
+            type: 'identifiers'
+            attributes:
+              category: 'doi'
+
+  tags:
+    - Nodes
+  operationId: nodes_identifiers_create
+  x-response-schema: Identifier
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        type: array
+        items:
+          $ref: '../identifiers/definition.yaml'
+      examples:
+        application/json:
+          data:
+          - relationships:
+              referent:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/nodes/73pnd/
+                    meta: {}
+            links:
+              self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b459/
+            attributes:
+              category: doi
+              value: 10.17605/OSF.IO/73PND
+            type: identifiers
+            id: 57f1641db83f6901ed94b459
+          links:
+            first:
+            last:
+            prev:
+            next:
+            meta:
+              total: 2
+              per_page: 10

--- a/swagger-spec/nodes/registrations_list.yaml
+++ b/swagger-spec/nodes/registrations_list.yaml
@@ -248,7 +248,15 @@ post:
       name: body
       required: true
       schema:
-        $ref: '../registrations/definition.yaml'
+        type: object
+        example:
+          data:
+            type: registrations
+            attributes:
+              draft_registration: '{draft_registration_id}'
+              registration_choice: embargo
+              lift_embargo: '2017-05-10T20:44:03.185000'
+              children: ['fsd2s', 'dwsa2']
   tags:
     - Nodes
   operationId: nodes_registrations_create

--- a/swagger-spec/registrations/definition.yaml
+++ b/swagger-spec/registrations/definition.yaml
@@ -24,6 +24,10 @@ properties:
       - draft_registration
       - registration_choice
     properties:
+      article_doi:
+        type: string
+        readOnly: false
+        description: 'The DOI of the associated journal article, as entered by the user, if the resource is published.'
       category:
         type: string
         readOnly: true
@@ -47,6 +51,10 @@ properties:
         type: boolean
         readOnly: true
         description: 'Whether or not the current user has permission to post comments on this registration. Comments on registrations can be set to allow all users to comment or restricted to only contributors.'
+      custom_citation:
+        type: string
+        readOnly: false
+        description: 'User-entered custom registration citation'
       current_user_permissions:
         type: array
         items:
@@ -75,7 +83,7 @@ properties:
         description: 'The time at which this registration was withdrawn, as an iso8601 formatted timestamp.'
       description:
         type: string
-        readOnly: true
+        readOnly: false
         description: 'The description of the registered node.'
       embargo_end_date:
         type: string
@@ -88,7 +96,7 @@ properties:
         description: 'Whether or not this registration represents a fork of another node.'
       node_license:
         type: string
-        readOnly: true
+        readOnly: false
         description: 'A dictionary containing the metadata (copyright year and holder) associated with the registered node license (required for certain license types).'
       pending_embargo_approval:
         type: boolean
@@ -126,7 +134,7 @@ properties:
         type: array
         items:
           type: string
-        readOnly: true
+        readOnly: false
         description: 'A list of strings that describe the registered node.'
       template_from:
         type: string
@@ -151,11 +159,11 @@ properties:
       draft_registration:
         type: string
         readOnly: false
-        description: 'The ID of the draft registration from which the registration will be created.'
+        description: 'Required on POST. The ID of the draft registration from which the registration will be created.'
       registration_choice:
         type: string
         readOnly: false
-        description: 'Describes when the registration will become public, either "immediate" or "embargo". If this field is "embargo", you will need to supply a datetime in the "lift_embargo" field.'
+        description: 'Required on POST. Describes when the registration will become public, either "immediate" or "embargo". If this field is "embargo", you will need to supply a datetime in the "lift_embargo" field.'
       lift_embargo:
         type: string
         format: date-time
@@ -175,7 +183,7 @@ properties:
     properties:
       affiliated_institutions:
         type: string
-        readOnly: true
+        readOnly: false
         description: 'A link to the list of institutions this registration is affiliated with.'
       children:
         type: string
@@ -205,6 +213,10 @@ properties:
         type: string
         readOnly: true
         description: 'A link to the list of identifiers for this registration (i.e. DOI identifiers).'
+      license:
+        type: string
+        readOnly: false
+        description: 'A relationship to the license that has been applied to the registration.'
       logs:
         type: string
         readOnly: true
@@ -261,12 +273,3 @@ properties:
         format: URL
         readOnly: true
         description: 'A link to the canonical API endpoint of this registration.'
-
-example:
-  data:
-    type: registrations
-    attributes:
-      draft_registration: '{draft_registration_id}'
-      registration_choice: embargo
-      lift_embargo: '2017-05-10T20:44:03.185000'
-      children: ['fsd2s', 'dwsa2']

--- a/swagger-spec/registrations/detail.yaml
+++ b/swagger-spec/registrations/detail.yaml
@@ -69,18 +69,17 @@ get:
 patch:
   summary: Update a registration
   description: >-
-    Updates a registration's privacy from **private** to **public**.
-
-
     Registrations can be updated with either a **PUT** or **PATCH** request.
-    The `public` field is the only field that can be modified on a registration
+    There are a handful of fields that can be edited by registration administrators,
+    and a few fields by users with write permissions.
 
-
-    Registrations can only be turned from private to public, not vice versa.
+    Note - one of the fields you can edit is `public`. Registrations can only be turned
+    from private to public, not vice versa.
 
     #### Permissions
 
-    Only project administrators may update a registration.
+    Only project administrators may update a registration (with a few exceptions). For example,
+    write contributors can edit tags.
 
     #### Returns
 
@@ -102,7 +101,29 @@ patch:
       name: body
       required: true
       schema:
-        $ref: definition.yaml
+        type: object
+        example:
+          data:
+            id: '9utb4'
+            type: 'registrations'
+            attributes:
+              description: 'my description'
+              tags: ['dogs', 'wolves']
+              node_license:
+                year: 2009
+                copyright_holders: ['Dennis Glenn']
+              custom_citation: 'Glenn, Dennis. My Registration, 2009.'
+              public: 'True'
+              article_doi: '10.12345/elephants'
+            relationships:
+              license:
+                 data:
+                   type: 'licenses'
+                   id: '5c3e3ddsaabb2400019b7c6a'
+              affiliated_institutions:
+                  data:
+                    type: 'institutions'
+                    id: 'cos'
   tags:
     - Registrations
   operationId: registrations_partial_update
@@ -110,4 +131,6 @@ patch:
     - application/json
   responses:
     '200':
-      description: 'Created'
+      description: 'OK'
+      schema:
+        $ref: definition.yaml

--- a/swagger-spec/registrations/identifiers_list.yaml
+++ b/swagger-spec/registrations/identifiers_list.yaml
@@ -57,7 +57,77 @@ get:
               referent:
                 links:
                   related:
-                    href: https://api.osf.io/v2/nodes/73pnd/
+                    href: https://api.osf.io/v2/registrations/73pnd/
+                    meta: {}
+            links:
+              self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b459/
+            attributes:
+              category: doi
+              value: 10.17605/OSF.IO/73PND
+            type: identifiers
+            id: 57f1641db83f6901ed94b459
+          links:
+            first:
+            last:
+            prev:
+            next:
+            meta:
+              total: 2
+              per_page: 10
+
+
+post:
+  summary: Create identifiers
+  description: >-
+    Create an identifier for a given registration - can only mint DOI's at this time.  Send
+    a POST request with a `category` attribute with a value of 'doi'.
+
+    #### Returns
+
+    
+    Returns a JSON object containing `data` and `links` keys.
+
+
+    The `data` key contains the created identifier object.
+
+
+  parameters:
+
+    - in: path
+      name: registration_id
+      type: string
+      required: true
+      description: 'The unique identifier of the registration.'
+    - in: body
+      name: body
+      required: true
+      schema:
+        type: object
+        example:
+          data:
+            type: 'identifiers'
+            attributes:
+              category: 'doi'
+
+  tags:
+    - Registrations
+  operationId: registrations_identifiers_create
+  x-response-schema: Identifier
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        type: array
+        items:
+          $ref: '../identifiers/definition.yaml'
+      examples:
+        application/json:
+          data:
+          - relationships:
+              referent:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/registrations/73pnd/
                     meta: {}
             links:
               self: https://api.osf.io/v2/identifiers/57f1641db83f6901ed94b459/


### PR DESCRIPTION
# Purpose

Add dev docs for editable registration fields and minting DOI's for nodes and registrations.

![screen shot 2019-02-04 at 9 44 46 pm](https://user-images.githubusercontent.com/9755598/52252434-16a51a80-28c8-11e9-84ad-47e2c79192e7.png)
![screen shot 2019-02-04 at 9 45 30 pm](https://user-images.githubusercontent.com/9755598/52252440-19077480-28c8-11e9-9cc6-687c1ec3808c.png)
![screen shot 2019-02-04 at 9 46 14 pm](https://user-images.githubusercontent.com/9755598/52252443-1b69ce80-28c8-11e9-98da-61645ac77a99.png)
![screen shot 2019-02-04 at 9 46 47 pm](https://user-images.githubusercontent.com/9755598/52252448-1d339200-28c8-11e9-8cf8-601fea70e8a0.png)
![screen shot 2019-02-04 at 9 47 08 pm](https://user-images.githubusercontent.com/9755598/52252450-1e64bf00-28c8-11e9-9924-12b90f275736.png)
