### PR TITLE
Modifying documentation for API Version 2.15

### DIFF
--- a/swagger-spec/files/version_definition.yaml
+++ b/swagger-spec/files/version_definition.yaml
@@ -8,7 +8,7 @@ properties:
   type:
     type: string
     readOnly: true
-    description: 'The type identifier of the file versions entity (`file_versions`).'
+    description: 'The type identifier of the file versions entity (`file-versions`).'
   attributes:
     type: object
     readOnly: true

--- a/swagger-spec/files/version_detail.yaml
+++ b/swagger-spec/files/version_detail.yaml
@@ -50,5 +50,5 @@ get:
               content_type: application/octet-stream
               date_created: '2017-01-01T12:34:56.78910'
               size: 216945
-            type: file_versions
+            type: file-versions
             id: '1'

--- a/swagger-spec/files/versions_list.yaml
+++ b/swagger-spec/files/versions_list.yaml
@@ -52,7 +52,7 @@ get:
               content_type: application/octet-stream
               date_created: '2017-01-01T12:34:56.78910'
               size: 216945
-            type: file_versions
+            type: file-versions
             id: '1'
           links:
             first:

--- a/swagger-spec/nodes/addon_detail.yaml
+++ b/swagger-spec/nodes/addon_detail.yaml
@@ -59,7 +59,7 @@ get:
               external_account_id: null
               folder_id: null
               node_has_auth: false
-            type: node_addons
+            type: node-addons
             id: box
 
 patch:
@@ -117,7 +117,7 @@ patch:
         type: object
         example:
           data:
-            type: node_addons
+            type: node-addons
             id: "{provider}"
             attributes:
               external_account_id: "{account_id}"

--- a/swagger-spec/nodes/addons_list.yaml
+++ b/swagger-spec/nodes/addons_list.yaml
@@ -48,7 +48,7 @@ get:
               external_account_id:
               folder_id:
               node_has_auth: false
-            type: node_addons
+            type: node-addons
             id: <provider_id>
           - links:
               self: http://api.osf.io/v2/nodes/gaz5n/addons/<another_provider_id>/
@@ -58,7 +58,7 @@ get:
               external_account_id:
               folder_id:
               node_has_auth: false
-            type: node_addons
+            type: node-addons
             id: <another_provider_id>
           links:
             first:

--- a/swagger-spec/nodes/draft_registration_definition.yaml
+++ b/swagger-spec/nodes/draft_registration_definition.yaml
@@ -15,7 +15,7 @@ properties:
   type:
     type: string
     readOnly: true
-    description: 'The type identifier of the draft registration entity (`draft_registrations`).'
+    description: 'The type identifier of the draft registration entity (`draft-registrations`).'
 
   attributes:
     type: object
@@ -80,9 +80,9 @@ properties:
 
 example:
   data:
-    type: 'draft_registrations'
+    type: 'draft-registrations'
     relationships:
       registration_schema:
           data:
               id: '{schema_id}'
-              type: registration_schemas
+              type: registration-schemas

--- a/swagger-spec/nodes/draft_registration_detail.yaml
+++ b/swagger-spec/nodes/draft_registration_detail.yaml
@@ -52,7 +52,7 @@ get:
         application/json:
           data:
           - id: ''
-            type: 'draft_registrations'
+            type: 'draft-registrations'
             attributes:
               datetime_initiated: ''
               datetime_updated: ''

--- a/swagger-spec/nodes/draft_registration_detail_definition.yaml
+++ b/swagger-spec/nodes/draft_registration_detail_definition.yaml
@@ -13,7 +13,7 @@ properties:
   type:
     type: string
     readOnly: true
-    description: 'The type identifier of the draft registration entity (`draft_registrations`).'
+    description: 'The type identifier of the draft registration entity (`draft-registrations`).'
 
   attributes:
     type: object
@@ -32,7 +32,7 @@ properties:
 example:
   data:
     id: '{draft_registration_id}'
-    type: 'draft_registrations'
+    type: 'draft-registrations'
     attributes:
       registration_metadata:
         datacompletion:

--- a/swagger-spec/nodes/draft_registrations_list.yaml
+++ b/swagger-spec/nodes/draft_registrations_list.yaml
@@ -53,7 +53,7 @@ get:
         application/json:
           data:
           - id: ''
-            type: 'draft_registrations'
+            type: 'draft-registrations'
             attributes:
               datetime_initiated: ''
               datetime_updated: ''

--- a/swagger-spec/nodes/node_addon_definition.yaml
+++ b/swagger-spec/nodes/node_addon_definition.yaml
@@ -12,7 +12,7 @@ properties:
   type:
     type: string
     readOnly: true
-    description: 'The type identifier of the node addon entity (`node_addons`).'
+    description: 'The type identifier of the node addon entity (`node-addons`).'
 
   attributes:
     type: object

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -893,7 +893,6 @@ tags:
           + `registration_schemas` has been changed to `registration-schemas`
           + `file_metadata_schemas` has been changed to `file-metadata-schemas`
 
-
       #### 2.14
 
       + Deprecates the `logo_path` field off of the InstitutionSerializer.

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -884,10 +884,19 @@ tags:
       Instead, to reset the client secret for an OAuth application, PATCH the
       `client_secret` property on the ApplicationDetail view (/v2/applications/<client_id>/)
 
+      + All types are now kebab-case. The following types have been changed.
+          + `draft_registrations` has been changed to `draft-registrations`
+          + `external_accounts` has been changed to `external-accounts`
+          + `file_versions` has been changed to `file-versions`
+          + `node_addons` has been changed to `node-addons`
+          + `user_addons` has been changed to `user-addons`
+          + `registration_schemas` has been changed to `registration-schemas`
+          + `file_metadata_schemas` has been changed to `file-metadata-schemas`
+
+
       #### 2.14
 
       + Deprecates the `logo_path` field off of the InstitutionSerializer.
-
 
       #### 2.13
 

--- a/swagger-spec/users/addon_account_definition.yaml
+++ b/swagger-spec/users/addon_account_definition.yaml
@@ -14,7 +14,7 @@ properties:
   type:
     type: string
     readOnly: true
-    description: 'The type identifier of the addon account entity (`external_accounts`).'
+    description: 'The type identifier of the addon account entity (`external-accounts`).'
 
   attributes:
     type: object

--- a/swagger-spec/users/addon_account_detail.yaml
+++ b/swagger-spec/users/addon_account_detail.yaml
@@ -60,5 +60,5 @@ get:
                 display_name: Fabrice Mizero
                 profile_url:
                 provider: dropbox
-              type: external_accounts
+              type: external-accounts
               id: 58d16ece9ad5a10201027eb4

--- a/swagger-spec/users/addon_accounts_list.yaml
+++ b/swagger-spec/users/addon_accounts_list.yaml
@@ -57,7 +57,7 @@ get:
               display_name: 'Fabrice Mizero'
               profile_url:
               provider: dropbox
-            type: external_accounts
+            type: external-accounts
             id: 58d16ece9ad5a10201027eb4
           links:
             first:

--- a/swagger-spec/users/addon_detail.yaml
+++ b/swagger-spec/users/addon_detail.yaml
@@ -56,5 +56,5 @@ get:
                   account: https://api.osf.io/v2/users/f542f/addons/dropbox/accounts/58d16ece9ad5a10201025eb4/
             attributes:
               user_has_auth: true
-            type: user_addons
+            type: user-addons
             id: dropbox

--- a/swagger-spec/users/addons_list.yaml
+++ b/swagger-spec/users/addons_list.yaml
@@ -64,7 +64,7 @@ get:
                   account: https://api.osf.io/v2/users/q7fts/addons/box/accounts/562d9acf8c5e4a14112e489e/
             attributes:
               user_has_auth: true
-            type: user_addons
+            type: user-addons
             id: box
           - links:
               self: https://api.osf.io/v2/users/me/addons/dropbox/
@@ -74,7 +74,7 @@ get:
                   account: https://api.osf.io/v2/users/q7fts/addons/dropbox/accounts/56742db88c5e4a396d689e3e/
             attributes:
               user_has_auth: true
-            type: user_addons
+            type: user-addons
             id: dropbox
           - links:
               self: https://api.osf.io/v2/users/me/addons/github/
@@ -85,7 +85,7 @@ get:
                   account: https://api.osf.io/v2/users/q7fts/addons/github/accounts/570edf7f9ad5a101f90030f6/
             attributes:
               user_has_auth: true
-            type: user_addons
+            type: user-addons
             id: github
           - links:
               self: https://api.osf.io/v2/users/me/addons/googledrive/
@@ -100,7 +100,7 @@ get:
                   account: https://api.osf.io/v2/users/q7fts/addons/googledrive/accounts/563c1c518c5e4a36e7dc5450/
             attributes:
               user_has_auth: true
-            type: user_addons
+            type: user-addons
             id: googledrive
           links:
             first:

--- a/swagger-spec/users/user_addon_definition.yaml
+++ b/swagger-spec/users/user_addon_definition.yaml
@@ -14,7 +14,7 @@ properties:
   type:
     type: string
     readOnly: true
-    description: 'The type identifier of the user addon entity (`user_addons`).'
+    description: 'The type identifier of the user addon entity (`user-addons`).'
 
   attributes:
     type: object


### PR DESCRIPTION
API Version 2.15 deprecates snake_case for all types and replaces with kebab-case. Also added documentation for API version 2.14 which was missing and deprecated the logo_path for institutions..