### PR TITLE
[ENG-357] Document /search/ API endpoints 

### DIFF
--- a/swagger-spec/search/components.yaml
+++ b/swagger-spec/search/components.yaml
@@ -1,1 +1,159 @@
 # /search/components/
+get:
+  summary: Search the OSF for components
+  description: >-
+    This endpoint returns components that have been found by the given Elasticsearch query. All components returned
+    are serialized a components.
+
+    #### Permissions
+
+    All accessible public materials are returned.
+
+    #### Filtering
+
+    The following query params allows the user to restrict their search.
+
+      - `?q=<Str>` -- Query to search projects, components, registrations, users, and files for.
+      - `?page=<Int>` -- page number of results to view, default 1
+  tags:
+    - Search
+  x-response-schema: 'Search'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: components_definition.yaml
+      examples:
+        application/json:
+          data:
+            - relationships:
+                files:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/files/
+                      meta: {}
+                view_only_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/view_only_links/
+                      meta: {}
+                citation:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/citation/
+                      meta: {}
+                draft_registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/draft_registrations/
+                      meta: {}
+                contributors:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/contributors/
+                      meta: {}
+                forks:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/forks/
+                      meta: {}
+                root:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/
+                      meta: {}
+                identifiers:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/identifiers/
+                      meta: {}
+                comments:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/comments/?filter%5Btarget%5D=ezcuj
+                      meta: {}
+                registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/registrations/
+                      meta: {}
+                node_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/node_links/
+                      meta: {}
+                linked_nodes:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/ezcuj/relationships/linked_nodes/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/linked_nodes/
+                      meta: {}
+                wikis:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/wikis/
+                      meta: {}
+                affiliated_institutions:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/ezcuj/relationships/institutions/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/institutions/
+                      meta: {}
+                children:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/children/
+                      meta: {}
+                preprints:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/preprints/
+                      meta: {}
+                logs:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/logs/
+                      meta: {}
+              links:
+                self: https://api.osf.io/v2/nodes/ezcuj/
+                html: https://osf.io/ezcuj/
+              attributes:
+                category: project
+                fork: false
+                preprint: false
+                description: ''
+                current_user_permissions:
+                - read
+                date_modified: '2016-12-08T21:45:17.058000'
+                title: 'Reproducibility Project: Psychology'
+                collection: false
+                registration: false
+                date_created: '2012-04-01T15:49:07.702000'
+                current_user_can_comment: true
+                node_license:
+                public: true
+                tags:
+                - replication
+                - reproducibility
+                - open science
+                - reproduction
+                - psychological science
+                - psychology
+                - metascience
+                - crowdsource
+              type: nodes
+              id: ezcuj
+          meta:
+            total: 2695768
+            per_page: 10
+            version: 2.14
+          links:
+            self: https://api.osf.io/v2/search/?page=2
+            first: https://api.osf.io/v2/search/
+            last: https://api.osf.io/v2/search/?page=269577
+            prev: https://api.osf.io/v2/search/
+            next: https://api.osf.io/v2/search/?page=3

--- a/swagger-spec/search/components.yaml
+++ b/swagger-spec/search/components.yaml
@@ -3,7 +3,7 @@ get:
   summary: Search the OSF for components
   description: >-
     This endpoint returns components that have been found by the given Elasticsearch query. All components returned
-    are serialized a components.
+    are serialized as components.
 
     #### Permissions
 

--- a/swagger-spec/search/components_definition.yaml
+++ b/swagger-spec/search/components_definition.yaml
@@ -1,0 +1,53 @@
+type: object
+title: Search
+
+properties:
+  data:
+    type: array
+    items:
+      type: object
+      $ref: '../nodes/definition.yaml'
+  meta:
+    type: object
+    title: Meta
+    properties:
+      total:
+        type: integer
+        description: 'The total number of items returned by the search.'
+      per_page:
+        type: integer
+        description: 'The number of results returned on a single page.'
+      version:
+        type: integer
+        description: 'The API version of OSF being used.'
+  links:
+    description: 'URLs to alternative representations of the search results.'
+    type: object
+    title: Links
+    required:
+      - self
+      - first
+      - last
+      - prev
+      - next
+    properties:
+      self:
+        type: string
+        format: URL
+        description: 'A link to the detail page for the log.'
+      first:
+        type: string
+        format: URL
+        description: 'A link to the first page of search results.'
+      last:
+        type: string
+        format: URL
+        description: 'A link to the last page of search results.'
+      prev:
+        type: string
+        format: URL
+        description: 'A link to the previous page of search results.'
+      next:
+        type: string
+        format: URL
+        description: 'A link to the next page of search results.'

--- a/swagger-spec/search/definition.yaml
+++ b/swagger-spec/search/definition.yaml
@@ -8,7 +8,7 @@ properties:
   data:
     type: array
     title: Data
-    description: "The search results, each item in this list will be serialized according to it's type."
+    description: "The search results; each item in this list will be serialized according to its type."
     items:
       type: object
   search_fields:

--- a/swagger-spec/search/definition.yaml
+++ b/swagger-spec/search/definition.yaml
@@ -1,0 +1,197 @@
+type: object
+title: Search
+required:
+  - id
+  - type
+  - attributes
+properties:
+  data:
+    type: array
+    title: Data
+    description: "The search results, each item in this list will be serialized according to it's type."
+    items:
+      type: object
+  search_fields:
+    type: object
+    title: Search Fields
+    description: 'URLs and total counts for different filtered searches.'
+    properties:
+      files:
+        type: object
+        description: 'The files returned by the search.'
+        properties:
+          related:
+            type: object
+            properties:
+              href:
+                type: string
+                format: URL
+              meta:
+                type: object
+                properties:
+                  total:
+                    type: integer
+      projects:
+        type: object
+        description: 'The project returned by the search.'
+        properties:
+          related:
+            type: object
+            properties:
+              href:
+                type: string
+                format: URL
+              meta:
+                type: object
+                properties:
+                  total:
+                    type: integer
+      components:
+        type: object
+        description: 'The components returned by the search.'
+        properties:
+          related:
+            type: object
+            properties:
+              href:
+                type: string
+                format: URL
+              meta:
+                type: object
+                properties:
+                  total:
+                    type: integer
+      registrations:
+        type: object
+        description: 'The registrations returned by the search.'
+        properties:
+          related:
+            type: object
+            properties:
+              href:
+                type: string
+                format: URL
+              meta:
+                type: object
+                properties:
+                  total:
+                    type: integer
+      users:
+        type: object
+        description: 'The users returned by the search.'
+        properties:
+          related:
+            type: object
+            properties:
+              href:
+                type: string
+                format: URL
+              meta:
+                type: object
+                properties:
+                  total:
+                    type: integer
+      institutions:
+        type: object
+        description: 'The institutions returned by the search.'
+        properties:
+          related:
+            type: object
+            properties:
+              href:
+                type: string
+                format: URL
+              meta:
+                type: object
+                properties:
+                  total:
+                    type: integer
+  meta:
+    description: 'Extra information about the request.'
+    type: object
+    title: Meta
+    properties:
+      total:
+        type: integer
+        description: 'The total number of items returned by the search.'
+      per_page:
+        type: integer
+        description: 'The number of results returned on a single page.'
+      version:
+        type: integer
+        description: 'The API version of OSF being used.'
+  links:
+    description: 'URLs to alternative representations of the search results.'
+    type: object
+    title: Links
+    required:
+      - self
+      - first
+      - last
+      - prev
+      - next
+    properties:
+      self:
+        type: string
+        format: URL
+        description: 'A link to the detail page for the log.'
+      first:
+        type: string
+        format: URL
+        description: 'A link to the first page of search results.'
+      last:
+        type: string
+        format: URL
+        description: 'A link to the last page of search results.'
+      prev:
+        type: string
+        format: URL
+        description: 'A link to the previous page of search results.'
+      next:
+        type: string
+        format: URL
+        description: 'A link to the next page of search results.'
+
+example:
+  data: {}
+  search_fields:
+    files:
+      related:
+        href: https://api.osf.io/v2/search/files/?q=%2A
+        meta:
+          total: 2337625
+    projects:
+      related:
+        href: https://api.osf.io/v2/search/projects/?q=%2A
+        meta:
+          total: 23423421
+    components:
+      related:
+        href: https://api.osf.io/v2/search/components/?q=%2A
+        meta:
+          total: 31312312
+    registrations:
+      related:
+        href: https://api.osf.io/v2/search/registrations/?q=%2A
+        meta:
+          total: 5234231231
+    users:
+      related:
+        href: https://api.osf.io/v2/search/users/?q=%2A
+        meta:
+          total: 3240450
+    institutions:
+      related:
+        href: https://api.osf.io/v2/search/institutions/?q=%2A
+        meta:
+          total: 42
+  meta:
+    total: 2695768
+    per_page: 10
+    version: 2.14
+  links:
+    self: https://api.osf.io/v2/search/?page=2
+    first: https://api.osf.io/v2/search/
+    last: https://api.osf.io/v2/search/?page=269577
+    prev: https://api.osf.io/v2/search/
+    next: https://api.osf.io/v2/search/?page=3

--- a/swagger-spec/search/files.yaml
+++ b/swagger-spec/search/files.yaml
@@ -2,7 +2,7 @@
 get:
   summary: Search the OSF for files
   description: >-
-    This endpoint returns that have been found by the given Elasticsearch query. All files returned are serialized as
+    This endpoint returns files that have been found by the given Elasticsearch query. All files returned are serialized as
     files.
 
     #### Permissions

--- a/swagger-spec/search/files.yaml
+++ b/swagger-spec/search/files.yaml
@@ -1,1 +1,86 @@
 # /search/files/
+get:
+  summary: Search the OSF for files
+  description: >-
+    This endpoint returns that have been found by the given Elasticsearch query. All files returned are serialized as
+    files.
+
+    #### Permissions
+
+    All accessible public materials are returned.
+
+    #### Filtering
+
+    The following query params allows the user to restract their search.
+
+      - `?q=<Str>` -- Query to search projects, components, registrations, users, and files for.
+      - `?page=<Int>` -- page number of results to view, default 1
+  tags:
+    - Search
+  x-response-schema: 'Search'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: 'files_definition.yaml'
+      examples:
+        application/json:
+          data:
+           -
+            relationships:
+              node:
+               links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/
+                      meta: {}
+               comments:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/comments/?filter%5Btarget%5D=sejcv
+                      meta: {}
+               versions:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/files/553e69248c5e4a219919ea54/versions/
+                      meta: {}
+            links:
+              info: https://api.osf.io/v2/files/553e69248c5e4a219919ea54/
+              self: https://api.osf.io/v2/files/553e69248c5e4a219919ea54/
+              move: https://files.osf.io/v1/resources/ezcuj/providers/osfstorage/553e69248c5e4a219919ea54
+              upload: https://files.osf.io/v1/resources/ezcuj/providers/osfstorage/553e69248c5e4a219919ea54
+              download: https://osf.io/download/sejcv
+              delete: https://files.osf.io/v1/resources/ezcuj/providers/osfstorage/553e69248c5e4a219919ea54
+              render: https://mfr.osf.io/render?url=https://osf.io/download/sejcv/?direct%26mode=render
+            attributes:
+              extra:
+                hashes:
+                  sha256: 2450eb9ff3db92a1bff370368b0552b270bd4b5ca0745b773c37d2662f94df8e
+                  md5: 44325d4f13b09f3769ede09d7c20a82c
+                downloads: 442
+              kind: file
+              name: OSC2012.pdf
+              last_touched: '2015-09-18T01:11:16.328000'
+              materialized_path: "/OSC2012.pdf"
+              date_modified: '2014-10-17T19:24:12.264Z'
+              current_version: 1
+              delete_allowed: true
+              date_created: '2014-10-17T19:24:12.264Z'
+              provider: osfstorage
+              path: "/553e69248c5e4a219919ea54"
+              current_user_can_comment: true
+              guid: sejcv
+              checkout:
+              tags: []
+              size: 216945
+            type: files
+            id: 553e69248c5e4a219919ea54
+          meta:
+            total: 2695768
+            per_page: 10
+            version: 2.14
+          links:
+            self: https://api.osf.io/v2/search/?page=2
+            first: https://api.osf.io/v2/search/
+            last: https://api.osf.io/v2/search/?page=269577
+            prev: https://api.osf.io/v2/search/
+            next: https://api.osf.io/v2/search/?page=3

--- a/swagger-spec/search/files_definition.yaml
+++ b/swagger-spec/search/files_definition.yaml
@@ -1,0 +1,53 @@
+type: object
+title: Search
+
+properties:
+  data:
+    type: array
+    items:
+      type: object
+      $ref: '../files/definition.yaml'
+  meta:
+    type: object
+    title: Meta
+    properties:
+      total:
+        type: integer
+        description: 'The total number of items returned by the search.'
+      per_page:
+        type: integer
+        description: 'The number of results returned on a single page.'
+      version:
+        type: integer
+        description: 'The API version of OSF being used.'
+  links:
+    description: 'URLs to alternative representations of the search results.'
+    type: object
+    title: Links
+    required:
+      - self
+      - first
+      - last
+      - prev
+      - next
+    properties:
+      self:
+        type: string
+        format: URL
+        description: 'A link to the detail page for the log.'
+      first:
+        type: string
+        format: URL
+        description: 'A link to the first page of search results.'
+      last:
+        type: string
+        format: URL
+        description: 'A link to the last page of search results.'
+      prev:
+        type: string
+        format: URL
+        description: 'A link to the previous page of search results.'
+      next:
+        type: string
+        format: URL
+        description: 'A link to the next page of search results.'

--- a/swagger-spec/search/institutions.yaml
+++ b/swagger-spec/search/institutions.yaml
@@ -1,0 +1,67 @@
+# /search/institutions/
+get:
+  summary: Search the OSF for our partner institutions
+  description: >-
+    This endpoint returns institutions which are utilitizing OSF and that have been found by the given Elasticsearch
+    query. All institutions returned are serialized as institutions.
+
+    #### Permissions
+
+    All accessible public materials are returned.
+
+    #### Filtering
+
+    The following query params allows the user to restrict their search.
+
+      - `?q=<Str>` -- Query to search projects, components, registrations, users, and files for.
+      - `?page=<Int>` -- page number of results to view, default 1
+  tags:
+    - Search
+  x-response-schema: 'Search'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: institutions_definition.yaml
+      examples:
+        application/json:
+          data:
+            - relationships:
+                nodes:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/institutions/cos/nodes/
+                      meta: {}
+                users:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/institutions/cos/users/
+                      meta: {}
+                registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/institutions/cos/registrations/
+                      meta: {}
+              links:
+                self: https://api.osf.io/v2/institutions/cos/
+                html: https://osf.io/institutions/cos/
+              attributes:
+                assets:
+                  logo: /static/img/institutions/shields/cos-shield.png
+                  logo_rounded: /static/img/institutions/shields-rounded-corners/cos-shield.png
+                auth_url: null
+                name: Center For Open Science
+                description: COS is a non-profit technology company providing free and open services to increase inclusivity and transparency of research. Find out more at <a href="https://cos.io">cos.io</a>.
+              type: institutions
+              id: cos
+
+          meta:
+            total: 42
+            per_page: 10
+            version: 2.14
+          links:
+            self: https://api.osf.io/v2/search/?page=2
+            first: https://api.osf.io/v2/search/
+            last: https://api.osf.io/v2/search/?page=269577
+            prev: https://api.osf.io/v2/search/
+            next: https://api.osf.io/v2/search/?page=3

--- a/swagger-spec/search/institutions_definition.yaml
+++ b/swagger-spec/search/institutions_definition.yaml
@@ -1,0 +1,53 @@
+type: object
+title: Search
+
+properties:
+  data:
+    type: array
+    items:
+      type: object
+      $ref: '../institutions/definition.yaml'
+  meta:
+    type: object
+    title: Meta
+    properties:
+      total:
+        type: integer
+        description: 'The total number of items returned by the search.'
+      per_page:
+        type: integer
+        description: 'The number of results returned on a single page.'
+      version:
+        type: integer
+        description: 'The API version of OSF being used.'
+  links:
+    description: 'URLs to alternative representations of the search results.'
+    type: object
+    title: Links
+    required:
+      - self
+      - first
+      - last
+      - prev
+      - next
+    properties:
+      self:
+        type: string
+        format: URL
+        description: 'A link to the detail page for the log.'
+      first:
+        type: string
+        format: URL
+        description: 'A link to the first page of search results.'
+      last:
+        type: string
+        format: URL
+        description: 'A link to the last page of search results.'
+      prev:
+        type: string
+        format: URL
+        description: 'A link to the previous page of search results.'
+      next:
+        type: string
+        format: URL
+        description: 'A link to the next page of search results.'

--- a/swagger-spec/search/projects.yaml
+++ b/swagger-spec/search/projects.yaml
@@ -3,7 +3,7 @@ get:
   summary: Search the OSF for projects
   description: >-
     This endpoint returns projects that have been found by the given Elasticsearch query. All projects returned
-    are serialized a projects.
+    are serialized as projects.
 
     #### Permissions
 

--- a/swagger-spec/search/projects.yaml
+++ b/swagger-spec/search/projects.yaml
@@ -1,1 +1,159 @@
 # /search/projects/
+get:
+  summary: Search the OSF for projects
+  description: >-
+    This endpoint returns projects that have been found by the given Elasticsearch query. All projects returned
+    are serialized a projects.
+
+    #### Permissions
+
+    All accessible public materials are returned.
+
+    #### Filtering
+
+    The following query params allows the user to restrict their search.
+
+      - `?q=<Str>` -- Query to search projects, components, registrations, users, and files for.
+      - `?page=<Int>` -- page number of results to view, default 1
+  tags:
+    - Search
+  x-response-schema: 'Search'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: projects_definition.yaml
+      examples:
+        application/json:
+          data:
+            - relationships:
+                files:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/files/
+                      meta: {}
+                view_only_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/view_only_links/
+                      meta: {}
+                citation:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/citation/
+                      meta: {}
+                draft_registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/draft_registrations/
+                      meta: {}
+                contributors:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/contributors/
+                      meta: {}
+                forks:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/forks/
+                      meta: {}
+                root:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/
+                      meta: {}
+                identifiers:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/identifiers/
+                      meta: {}
+                comments:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/comments/?filter%5Btarget%5D=ezcuj
+                      meta: {}
+                registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/registrations/
+                      meta: {}
+                node_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/node_links/
+                      meta: {}
+                linked_nodes:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/ezcuj/relationships/linked_nodes/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/linked_nodes/
+                      meta: {}
+                wikis:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/wikis/
+                      meta: {}
+                affiliated_institutions:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/ezcuj/relationships/institutions/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/institutions/
+                      meta: {}
+                children:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/children/
+                      meta: {}
+                preprints:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/preprints/
+                      meta: {}
+                logs:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/logs/
+                      meta: {}
+              links:
+                self: https://api.osf.io/v2/nodes/ezcuj/
+                html: https://osf.io/ezcuj/
+              attributes:
+                category: project
+                fork: false
+                preprint: false
+                description: ''
+                current_user_permissions:
+                - read
+                date_modified: '2016-12-08T21:45:17.058000'
+                title: 'Reproducibility Project: Psychology'
+                collection: false
+                registration: false
+                date_created: '2012-04-01T15:49:07.702000'
+                current_user_can_comment: true
+                node_license:
+                public: true
+                tags:
+                - replication
+                - reproducibility
+                - open science
+                - reproduction
+                - psychological science
+                - psychology
+                - metascience
+                - crowdsource
+              type: nodes
+              id: ezcuj
+          meta:
+            total: 2695768
+            per_page: 10
+            version: 2.14
+          links:
+            self: https://api.osf.io/v2/search/?page=2
+            first: https://api.osf.io/v2/search/
+            last: https://api.osf.io/v2/search/?page=269577
+            prev: https://api.osf.io/v2/search/
+            next: https://api.osf.io/v2/search/?page=3

--- a/swagger-spec/search/projects_definition.yaml
+++ b/swagger-spec/search/projects_definition.yaml
@@ -1,0 +1,53 @@
+type: object
+title: Search
+
+properties:
+  data:
+    type: array
+    items:
+      type: object
+      $ref: '../nodes/definition.yaml'
+  meta:
+    type: object
+    title: Meta
+    properties:
+      total:
+        type: integer
+        description: 'The total number of items returned by the search.'
+      per_page:
+        type: integer
+        description: 'The number of results returned on a single page.'
+      version:
+        type: integer
+        description: 'The API version of OSF being used.'
+  links:
+    description: 'URLs to alternative representations of the search results.'
+    type: object
+    title: Links
+    required:
+      - self
+      - first
+      - last
+      - prev
+      - next
+    properties:
+      self:
+        type: string
+        format: URL
+        description: 'A link to the detail page for the log.'
+      first:
+        type: string
+        format: URL
+        description: 'A link to the first page of search results.'
+      last:
+        type: string
+        format: URL
+        description: 'A link to the last page of search results.'
+      prev:
+        type: string
+        format: URL
+        description: 'A link to the previous page of search results.'
+      next:
+        type: string
+        format: URL
+        description: 'A link to the next page of search results.'

--- a/swagger-spec/search/registrations.yaml
+++ b/swagger-spec/search/registrations.yaml
@@ -3,7 +3,7 @@ get:
   summary: Search the OSF for registrations
   description: >-
     This endpoint returns registrations that have been found by the given Elasticsearch query. All registrations
-    returned are serialized a registrations.
+    returned are serialized as registrations.
 
     #### Permissions
 

--- a/swagger-spec/search/registrations.yaml
+++ b/swagger-spec/search/registrations.yaml
@@ -1,1 +1,159 @@
 # /search/registrations/
+get:
+  summary: Search the OSF for registrations
+  description: >-
+    This endpoint returns registrations that have been found by the given Elasticsearch query. All registrations
+    returned are serialized a registrations.
+
+    #### Permissions
+
+    All accessible public materials are returned.
+
+    #### Filtering
+
+    The following query params allows the user to restrict their search.
+
+      - `?q=<Str>` -- Query to search projects, components, registrations, users, and files for.
+      - `?page=<Int>` -- page number of results to view, default 1
+  tags:
+    - Search
+  x-response-schema: 'Search'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: registrations_definition.yaml
+      examples:
+        application/json:
+          data:
+            - relationships:
+                files:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/files/
+                      meta: {}
+                view_only_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/view_only_links/
+                      meta: {}
+                citation:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/citation/
+                      meta: {}
+                draft_registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/draft_registrations/
+                      meta: {}
+                contributors:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/contributors/
+                      meta: {}
+                forks:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/forks/
+                      meta: {}
+                root:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/
+                      meta: {}
+                identifiers:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/identifiers/
+                      meta: {}
+                comments:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/comments/?filter%5Btarget%5D=ezcuj
+                      meta: {}
+                registrations:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/registrations/
+                      meta: {}
+                node_links:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/node_links/
+                      meta: {}
+                linked_nodes:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/ezcuj/relationships/linked_nodes/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/linked_nodes/
+                      meta: {}
+                wikis:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/wikis/
+                      meta: {}
+                affiliated_institutions:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/nodes/ezcuj/relationships/institutions/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/institutions/
+                      meta: {}
+                children:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/children/
+                      meta: {}
+                preprints:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/preprints/
+                      meta: {}
+                logs:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/nodes/ezcuj/logs/
+                      meta: {}
+              links:
+                self: https://api.osf.io/v2/nodes/ezcuj/
+                html: https://osf.io/ezcuj/
+              attributes:
+                category: project
+                fork: false
+                preprint: false
+                description: ''
+                current_user_permissions:
+                - read
+                date_modified: '2016-12-08T21:45:17.058000'
+                title: 'Reproducibility Project: Psychology'
+                collection: false
+                registration: false
+                date_created: '2012-04-01T15:49:07.702000'
+                current_user_can_comment: true
+                node_license:
+                public: true
+                tags:
+                - replication
+                - reproducibility
+                - open science
+                - reproduction
+                - psychological science
+                - psychology
+                - metascience
+                - crowdsource
+              type: nodes
+              id: ezcuj
+          meta:
+            total: 2695768
+            per_page: 10
+            version: 2.14
+          links:
+            self: https://api.osf.io/v2/search/?page=2
+            first: https://api.osf.io/v2/search/
+            last: https://api.osf.io/v2/search/?page=269577
+            prev: https://api.osf.io/v2/search/
+            next: https://api.osf.io/v2/search/?page=3

--- a/swagger-spec/search/registrations_definition.yaml
+++ b/swagger-spec/search/registrations_definition.yaml
@@ -1,0 +1,53 @@
+type: object
+title: Search
+
+properties:
+  data:
+    type: array
+    items:
+      type: object
+      $ref: '../registrations/definition.yaml'
+  meta:
+    type: object
+    title: Meta
+    properties:
+      total:
+        type: integer
+        description: 'The total number of items returned by the search.'
+      per_page:
+        type: integer
+        description: 'The number of results returned on a single page.'
+      version:
+        type: integer
+        description: 'The API version of OSF being used.'
+  links:
+    description: 'URLs to alternative representations of the search results.'
+    type: object
+    title: Links
+    required:
+      - self
+      - first
+      - last
+      - prev
+      - next
+    properties:
+      self:
+        type: string
+        format: URL
+        description: 'A link to the detail page for the log.'
+      first:
+        type: string
+        format: URL
+        description: 'A link to the first page of search results.'
+      last:
+        type: string
+        format: URL
+        description: 'A link to the last page of search results.'
+      prev:
+        type: string
+        format: URL
+        description: 'A link to the previous page of search results.'
+      next:
+        type: string
+        format: URL
+        description: 'A link to the next page of search results.'

--- a/swagger-spec/search/search.yaml
+++ b/swagger-spec/search/search.yaml
@@ -2,9 +2,10 @@
 get:
   summary: Search the OSF
   description: >-
-    Objects (including projects, components, registrations, users, files, and institutions) that have been found by the
-    given Elasticsearch query. Each object is serialized with the appropriate serializer for its type (files are
-    serialized as files, users are serialized as users, etc.) and returned collectively.
+    OSF search returns JSON serialized objects (including projects, components, registrations, users, files,
+     and institutions) that have been found by the given Elasticsearch query. Each object is serialized with the
+     appropriate serializer for its type (files are serialized as files, users are serialized as users, etc.) and
+     returned collectively.
 
     #### Permissions
 

--- a/swagger-spec/search/search.yaml
+++ b/swagger-spec/search/search.yaml
@@ -1,1 +1,26 @@
 # /search/
+get:
+  summary: Search the OSF
+  description: >-
+    Objects (including projects, components, registrations, users, files, and institutions) that have been found by the
+    given Elasticsearch query. Each object is serialized with the appropriate serializer for its type (files are
+    serialized as files, users are serialized as users, etc.) and returned collectively.
+
+    #### Permissions
+
+    All accessible public materials are returned.
+
+    #### Filtering
+
+    The following query params allows the user to restract their search.
+
+      - `?q=<Str>` -- Query to search projects, components, registrations, users, and files for.
+      - `?page=<Int>` -- page number of results to view, default 1
+  tags:
+    - Search
+  x-response-schema: 'Search'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: definition.yaml

--- a/swagger-spec/search/users.yaml
+++ b/swagger-spec/search/users.yaml
@@ -3,7 +3,7 @@ get:
   summary: Search the OSF for users
   description: >-
     This endpoint returns users that have been found by the given Elasticsearch query. All users returned
-    are serialized a user.
+    are serialized as users.
 
     #### Permissions
 

--- a/swagger-spec/search/users.yaml
+++ b/swagger-spec/search/users.yaml
@@ -1,1 +1,68 @@
 # /search/users/
+get:
+  summary: Search the OSF for users
+  description: >-
+    This endpoint returns users that have been found by the given Elasticsearch query. All users returned
+    are serialized a user.
+
+    #### Permissions
+
+    All accessible public materials are returned.
+
+    #### Filtering
+
+    The following query params allows the user to restrict their search.
+
+      - `?q=<Str>` -- Query to search projects, components, registrations, users, and files for.
+      - `?page=<Int>` -- page number of results to view, default 1
+  tags:
+    - Search
+  x-response-schema: 'Search'
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: users_definition.yaml
+      examples:
+        application/json:
+          data:
+            - relationships:
+                nodes:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/users/q7fts/nodes/
+                      meta: {}
+                institutions:
+                  links:
+                    self:
+                      href: https://api.osf.io/v2/users/q7fts/relationships/institutions/
+                      meta: {}
+                    related:
+                      href: https://api.osf.io/v2/users/q7fts/institutions/
+                      meta: {}
+              links:
+                self: https://api.osf.io/v2/users/q7fts/
+                html: https://osf.io/q7fts/
+                profile_image: https://secure.gravatar.com/avatar/e9d9311ab2f5ab7492a86ac9adb5c8e9?d=identicon
+              attributes:
+                family_name: Rollins
+                suffix: ''
+                locale: en_US
+                date_registered: '2014-06-15T17:39:06.701000'
+                middle_names: ''
+                given_name: Casey
+                full_name: Casey Rollins
+                active: true
+                timezone: America/New_York
+              type: users
+              id: q7fts
+          meta:
+            total: 2695768
+            per_page: 10
+            version: 2.14
+          links:
+            self: https://api.osf.io/v2/search/?page=2
+            first: https://api.osf.io/v2/search/
+            last: https://api.osf.io/v2/search/?page=269577
+            prev: https://api.osf.io/v2/search/
+            next: https://api.osf.io/v2/search/?page=3

--- a/swagger-spec/search/users_definition.yaml
+++ b/swagger-spec/search/users_definition.yaml
@@ -1,0 +1,53 @@
+type: object
+title: Search
+
+properties:
+  data:
+    type: array
+    items:
+      type: object
+      $ref: '../users/definition.yaml'
+  meta:
+    type: object
+    title: Meta
+    properties:
+      total:
+        type: integer
+        description: 'The total number of items returned by the search.'
+      per_page:
+        type: integer
+        description: 'The number of results returned on a single page.'
+      version:
+        type: integer
+        description: 'The API version of OSF being used.'
+  links:
+    description: 'URLs to alternative representations of the search results.'
+    type: object
+    title: Links
+    required:
+      - self
+      - first
+      - last
+      - prev
+      - next
+    properties:
+      self:
+        type: string
+        format: URL
+        description: 'A link to the detail page for the log.'
+      first:
+        type: string
+        format: URL
+        description: 'A link to the first page of search results.'
+      last:
+        type: string
+        format: URL
+        description: 'A link to the last page of search results.'
+      prev:
+        type: string
+        format: URL
+        description: 'A link to the previous page of search results.'
+      next:
+        type: string
+        format: URL
+        description: 'A link to the next page of search results.'

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -35,7 +35,7 @@ x-tagGroups:
       - Entities & Entity Collections
       - External Libraries
       - Changelog
-      - Search
+      - Searching
   - name: API Reference
     tags:
       - Addons
@@ -979,7 +979,7 @@ tags:
 
       + Deprecate the `node_links` field in the **Node** and **Registration** serializers in favor of `linked_nodes` and `linked_registrations`.
 
-  - name: Search
+  - name: Searching
     x-traitTag: true
     description: >-
       OSF public resources and partner institutions can queried via the `/v2/search/` endpoint. The search endpoint will

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -35,6 +35,7 @@ x-tagGroups:
       - Entities & Entity Collections
       - External Libraries
       - Changelog
+      - Search
   - name: API Reference
     tags:
       - Addons
@@ -50,6 +51,7 @@ x-tagGroups:
       - Preprints
       - Preprint Providers
       - Registrations
+      - Search
       - Taxonomies
       - Users
       - View Only Links
@@ -977,6 +979,20 @@ tags:
 
       + Deprecate the `node_links` field in the **Node** and **Registration** serializers in favor of `linked_nodes` and `linked_registrations`.
 
+  - name: Search
+    x-traitTag: true
+    description: >-
+      OSF public resources and partner institutions can queried via the `/v2/search/` endpoint. The search endpoint will
+      return a serialized JSON representation of the queried object.
+
+      OSF search uses the [Lucene search syntax](http://extensions.xwiki.org/xwiki/bin/view/Extension/Search+Application+Query+Syntax)
+      .This gives you many options, but can be very simple as well. Examples of
+      valid searches include:
+
+       - https://osf.io/search/?q=repro*
+       - https://osf.io/search/?q=brian+AND+title:many
+       - https://osf.io/search/?q=tags:(psychology)
+
 paths:
 
   ##############
@@ -1305,6 +1321,31 @@ paths:
 
   /registrations/{registration_id}/wikis/:
     $ref: 'registrations/wikis_list.yaml'
+
+  ##############
+  #   SEARCH   #
+  ##############
+
+  /search/:
+    $ref: 'search/search.yaml'
+
+  /search/files/:
+    $ref: 'search/files.yaml'
+
+  /search/projects/:
+    $ref: 'search/projects.yaml'
+
+  /search/components/:
+    $ref: 'search/components.yaml'
+
+  /search/registrations/:
+    $ref: 'search/registrations.yaml'
+
+  /search/users/:
+    $ref: 'search/users.yaml'
+
+  /search/institutions/:
+    $ref: 'search/institutions.yaml'
 
   ##################
   #   TAXONOMIES   #


### PR DESCRIPTION
## Purpose

To document the existence of our search!

## Changes

Add docs for general search endpoint: `/v2/search/` and the filtered endpoints `/v2/search/files` etc. Also adds some search syntax info.

## Side Effect

None that I know of.

## Tickets

https://openscience.atlassian.net/browse/ENG-357