### PR TITLE
[ENG-2480] Add no-project registrations 

### DIFF
--- a/swagger-spec/collections/collected_metadata_subjects.yaml
+++ b/swagger-spec/collections/collected_metadata_subjects.yaml
@@ -56,20 +56,20 @@ get:
                 children:
                   links:
                     related:
-                      href: http://localhost:8000/v2/subjects/5fd228b7e64e1300aa99ee15/children/
+                      href: https://api.osf.io/v2/subjects/5fd228b7e64e1300aa99ee15/children/
                       meta: { }
               embeds:
                 parent:
                   errors:
                     - detail: Not found.
               links:
-                self: http://localhost:8000/v2/subjects/5fd228b7e64e1300aa99ee15/
+                self: https://api.osf.io/v2/subjects/5fd228b7e64e1300aa99ee15/
           meta:
             total: 1
             per_page: 10
             version: '2.20'
           links:
-            self: http://localhost:8000/v2/collections/nywr6/collected_metadata/zjxhs/subjects/
+            self: https://api.osf.io/v2/collections/nywr6/collected_metadata/zjxhs/subjects/
             first:
             last:
             prev:

--- a/swagger-spec/draft_registrations/draft_registration_definition.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_definition.yaml
@@ -38,9 +38,21 @@ properties:
         readOnly: false
         description: 'The searchable tags of the Draft Registration.'
       node_license:
-        type: string
-        readOnly: false
-        description: 'The license for the Draft Registration.'
+        type: object
+        title: Node License
+        properties:
+          copyright_holders:
+            type: array
+            readOnly: true
+            description: 'A list of names of copyright holders for the license.'
+            items:
+              type: string
+              readOnly: true
+              description: 'A copyright holders for the license.'
+          year:
+            type: integer
+            readOnly: true
+            description: 'The year the copyright was made.'
       current_user_permissions:
         type: array
         items:

--- a/swagger-spec/draft_registrations/draft_registration_definition.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_definition.yaml
@@ -34,7 +34,9 @@ properties:
         readOnly: false
         description: 'The category of the Draft Registration.'
       tags:
-        type: string
+        type: array
+        items:
+          type: string
         readOnly: false
         description: 'The searchable tags of the Draft Registration.'
       node_license:

--- a/swagger-spec/draft_registrations/draft_registration_definition.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_definition.yaml
@@ -59,7 +59,7 @@ properties:
         type: array
         items:
           type: string
-        readOnly: false
+        readOnly: true
         description: 'The current users permission level for the Draft Registration.'
       has_project:
         type: boolean

--- a/swagger-spec/draft_registrations/draft_registration_definition.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_definition.yaml
@@ -11,22 +11,46 @@ properties:
     type: string
     readOnly: true
     description: 'The unique identifier of the draft registration entity.'
-
   type:
     type: string
     readOnly: true
     description: 'The type identifier of the draft registration entity (`draft_registrations`).'
-
   attributes:
     type: object
     title: Attributes
     readOnly: false
-    description: 'The properties of the draft registration entity.'
-    required:
-      - datetime_initiated
-      - datetime_updated
-      - registration_supplement
+    description: 'The properties of the Draft Registration entity.'
     properties:
+      title:
+        type: string
+        readOnly: false
+        description: 'The title of the Draft Registration.'
+      description:
+        type: string
+        readOnly: false
+        description: 'The description of the Draft Registration.'
+      category:
+        type: string
+        readOnly: false
+        description: 'The category of the Draft Registration.'
+      tags:
+        type: string
+        readOnly: false
+        description: 'The searchable tags of the Draft Registration.'
+      node_license:
+        type: string
+        readOnly: false
+        description: 'The license for the Draft Registration.'
+      current_user_permissions:
+        type: array
+        items:
+          type: string
+        readOnly: false
+        description: 'The current users permission level for the Draft Registration.'
+      has_project:
+        type: boolean
+        readOnly: true
+        description: 'This indicates whether a Draft Registration was branched from a project.'
       datetime_initiated:
         type: string
         format: date-time
@@ -40,20 +64,15 @@ properties:
       registration_metadata:
         type: string
         readOnly: false
-        description: 'A dictionary of question IDs and responses from the registration schema.'
-      registration_supplement:
+        description: 'This is a legacy format for `registration_responses`.'
+      registration_responses:
         type: string
         readOnly: false
-        description: 'The ID of an active registration schema that this registration will conform to.'
-
+        description: 'A dictionary of question IDs and responses from the registration schema.'
   relationships:
     type: object
     title: Relationships
     readOnly: true
-    required:
-      - branched_from
-      - initiator
-      - registration_schema
     description: 'URLs to other entities or entity collections that have a relationship to the draft registration entity.'
     properties:
       branched_from:
@@ -68,7 +87,6 @@ properties:
         type: string
         readOnly: true
         description: 'A link to the detailed registration schema that this draft conforms to.'
-
   links:
     type: object
     title: Links
@@ -85,7 +103,9 @@ properties:
 
 example:
   data:
-    type: 'draft_registrations'
-    attributes:
-      registration_supplement: '{schema_id}'
-
+    type: draft_registrations
+    relationships:
+      registration_schema:
+        data:
+          id: 61e02b6c90de34000ae3447a
+          type: registration_schemas

--- a/swagger-spec/draft_registrations/draft_registration_definition.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_definition.yaml
@@ -45,7 +45,7 @@ properties:
         properties:
           copyright_holders:
             type: array
-            readOnly: true
+            readOnly: false
             description: 'A list of names of copyright holders for the license.'
             items:
               type: string
@@ -53,7 +53,7 @@ properties:
               description: 'A copyright holders for the license.'
           year:
             type: integer
-            readOnly: true
+            readOnly: false
             description: 'The year the copyright was made.'
       current_user_permissions:
         type: array
@@ -76,11 +76,11 @@ properties:
         readOnly: true
         description: 'The time at which the draft registration was last updated, as an iso8601 formatted timestamp.'
       registration_metadata:
-        type: string
+        type: object
         readOnly: false
         description: 'This is a legacy format for `registration_responses`.'
       registration_responses:
-        type: string
+        type: object
         readOnly: false
         description: 'A dictionary of question IDs and responses from the registration schema.'
   relationships:

--- a/swagger-spec/draft_registrations/draft_registration_detail.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_detail.yaml
@@ -4,7 +4,7 @@ get:
     Retrieve the details of a given Draft Registration
 
     Draft Registrations contain Registration questions that will become part of the Registration.
-    A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+    A Registration is a frozen version of the project that can never be deleted, but can be withdrawn and have it's metadata edited.
 
 
     If you based your Draft Registration on a Project, your original Project remains editable but will now have

--- a/swagger-spec/draft_registrations/draft_registration_detail.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_detail.yaml
@@ -117,7 +117,7 @@ patch:
   description: >-
     Updates a Draft Registration by setting the values of the attributes specified in the request body.
     Any unspecified attributes will be left unchanged. Note this will not register or change the machine state of a
-    Draft Registration, it can only edit the Draft Registration's attributes prior to it's registration.
+    Draft Registration, it can only edit the Draft Registration's attributes prior to its registration.
 
     #### Permissions
 

--- a/swagger-spec/draft_registrations/draft_registration_detail.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_detail.yaml
@@ -121,7 +121,8 @@ patch:
 
     #### Permissions
 
-    Only draft registration contributors may view draft registrations.
+    Only draft registration contributors may view draft registrations and only draft registration contributors with
+    WRITE or ADMIN permissions may update draft registrations.
 
     #### Returns
 
@@ -174,7 +175,7 @@ patch:
                   value: ''
                   extra: []
               registration_responses:
-                summary: Test
+                summary: Test Value
               datetime_initiated: '2022-05-02T15:43:22.981108'
               datetime_updated: '2022-05-03T18:34:29.504428'
               title: test title change
@@ -247,7 +248,7 @@ delete:
 
     #### Permissions
 
-    Only draft registration contributors may view draft registrations.
+    Only draft registration contributors with ADMIN permissions may delete draft registrations
 
     #### Returns
 

--- a/swagger-spec/draft_registrations/draft_registration_detail.yaml
+++ b/swagger-spec/draft_registrations/draft_registration_detail.yaml
@@ -1,0 +1,270 @@
+get:
+  summary: Retrieve a Draft Registration
+  description: >-
+    Retrieve the details of a given Draft Registration
+
+    Draft Registrations contain Registration questions that will become part of the Registration.
+    A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+
+
+    If you based your Draft Registration on a Project, your original Project remains editable but will now have
+    the Draft Registration linked to it.
+
+    #### Permissions
+
+    Only draft registration contributors may view draft registrations.
+
+    #### Returns
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    draft registration, if the request is successful.
+
+
+    If the request is unsuccessful, an `errors` key containing information about the failure will be returned.
+    Refer to the [list of error codes](#tag/Errors-and-Error-Codes) to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      name: draft_id
+      required: true
+      description: 'The unique identifier of the draft registration.'
+  tags:
+    - Draft Registrations
+  operationId: nodes_draft_registrations_read
+  x-response-schema: Draft Registration
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: draft_registration_definition.yaml
+      examples:
+        application/json:
+          data:
+            id: 626ffc1ad90ebe0011fc7601
+            type: draft-registrations
+            attributes:
+              registration_metadata: { }
+              registration_responses: { }
+              datetime_initiated: '2022-05-02T15:43:22.981108Z'
+              datetime_updated: '2022-05-03T13:08:47.334711Z'
+              title: Untitled
+              description: ''
+              category: ''
+              tags: [ ]
+              node_license:
+            relationships:
+              initiator:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/users/fgvc6/
+                    meta: { }
+                data:
+                  id: fgvc6
+                  type: users
+              branched_from:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_nodes/ng4w2/
+                    meta: { }
+              registration_schema:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/schemas/registrations/61e02b6c90de34000ae3447a/
+                    meta: { }
+                data:
+                  id: 61e02b6c90de34000ae3447a
+                  type: registration-schemas
+              provider:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/providers/registrations/osf/
+                    meta: { }
+                data:
+                  id: osf
+                  type: registration-providers
+              affiliated_institutions:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/institutions/
+                    meta: { }
+                  self:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/relationships/institutions/
+                    meta: { }
+              contributors:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/contributors/
+                    meta: { }
+              license:
+                data:
+              subjects:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/subjects/
+                    meta: { }
+                  self:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/relationships/subjects/
+                    meta: { }
+            links:
+              self: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/
+          meta:
+            version: '2.20'
+
+
+patch:
+  summary: Update a Draft Registration
+  description: >-
+    Updates a Draft Registration by setting the values of the attributes specified in the request body.
+    Any unspecified attributes will be left unchanged. Note this will not register or change the machine state of a
+    Draft Registration, it can only edit the Draft Registration's attributes prior to it's registration.
+
+    #### Permissions
+
+    Only draft registration contributors may view draft registrations.
+
+    #### Returns
+
+    Returns a JSON object with a `data` key containing the new representation of the updated draft registration, if the request is successful.
+
+    If the request is unsuccessful, an `errors` key containing information about the failure will be returned.
+    Refer to the [list of error codes](#tag/Errors-and-Error-Codes) to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      name: draft_id
+      required: true
+      description: 'The unique identifier of the draft registration.'
+    - in: body
+      name: body
+      required: true
+      schema:
+        type: object
+        example:
+          data:
+            id: 626ffc1ad90ebe0011fc7601
+            type: draft_registrations
+            attributes:
+              title: test title change
+              registration_responses:
+                summary: Test Value
+  tags:
+    - Draft Registrations
+  operationId: nodes_draft_registrations_partial_update
+  x-response-schema: Draft Registration
+  consumes:
+    - application/json
+  responses:
+    '200':
+      description: OK
+      examples:
+        application/json:
+          data:
+            id: 626ffc1ad90ebe0011fc7601
+            type: draft_registrations
+            attributes:
+              registration_metadata:
+                summary:
+                  comments: []
+                  value: Test
+                  extra: []
+                uploader:
+                  comments: []
+                  value: ''
+                  extra: []
+              registration_responses:
+                summary: Test
+              datetime_initiated: '2022-05-02T15:43:22.981108'
+              datetime_updated: '2022-05-03T18:34:29.504428'
+              title: test title change
+              description: ''
+              category: ''
+              tags: []
+              node_license: None
+            relationships:
+              initiator:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/users/fgvc6/
+                    meta: {}
+                data:
+                  id: fgvc6
+                  type: users
+              branched_from:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_nodes/ng4w2/
+                    meta: {}
+              registration_schema:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/schemas/registrations/61e02b6c90de34000ae3447a/
+                    meta: {}
+                data:
+                  id: 61e02b6c90de34000ae3447a
+                  type: registration-schemas
+              provider:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/providers/registrations/osf/
+                    meta: {}
+                data:
+                  id: osf
+                  type: registration-providers
+              affiliated_institutions:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/institutions/
+                    meta: {}
+                  self:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/relationships/institutions/
+                    meta: {}
+              contributors:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/contributors/
+                    meta: {}
+              subjects:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/subjects/
+                    meta: {}
+                  self:
+                    href: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/relationships/subjects/
+                    meta: {}
+            links:
+              self: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/
+          meta:
+            version: '2.0'
+
+
+delete:
+  summary: Delete a draft registration
+  description: >-
+    Permanently deletes a draft registration.
+    A draft that has already been registered cannot be deleted.
+
+    #### Permissions
+
+    Only draft registration contributors may view draft registrations.
+
+    #### Returns
+
+    If the request is successful, no content is returned.
+
+    If the request is unsuccessful, a JSON object with an `errors` key containing information about the failure will be returned.
+    Refer to the [list of error codes]() to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      name: draft_id
+      required: true
+      description: 'The unique identifier of the draft registration.'
+  tags:
+    - Draft Registrations
+  operationId: nodes_draft_registrations_delete
+  responses:
+    '204':
+      description: 'No Content'

--- a/swagger-spec/draft_registrations/draft_registrations_contributors_detail.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_contributors_detail.yaml
@@ -4,11 +4,12 @@ get:
     Retrieves the details of a given contributor.
 
 
-    Contributors are users who can make changes to the node or, in the case of private nodes, have read access to the node.
+    Contributors are users who can view or edit to the Draft Registrations.
 
 
     Contributors are categorized as either "bibliographic" or "non-bibliographic".
-    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
+    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are
+    listed on the project overview page on the OSF, while non-bibliographic contributors are not.
 
   parameters:
     - in: path

--- a/swagger-spec/draft_registrations/draft_registrations_contributors_detail.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_contributors_detail.yaml
@@ -1,0 +1,149 @@
+get:
+  summary: Retreive a Contributor from a Draft Registration
+  description: >-
+    Retrieves the details of a given contributor.
+
+
+    Contributors are users who can make changes to the node or, in the case of private nodes, have read access to the node.
+
+
+    Contributors are categorized as either "bibliographic" or "non-bibliographic".
+    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
+
+  parameters:
+    - in: path
+      type: string
+      name: draft_id
+      required: true
+      description: 'The unique identifier of the Draft Registration.'
+    - in: path
+      type: string
+      name: user_id
+      required: true
+      description: 'The unique identifier of the Contributor.'
+  tags:
+    - Draft Registrations
+  operationId: draft_registration_contributors_create
+  x-response-schema: Contributor
+  consumes:
+    - application/json
+  responses:
+    '200':
+      description: 'Success'
+      examples:
+        application/json:
+          data:
+            id: 626170854968470203611e2c-gyht4
+            type: contributors
+            attributes:
+              index: 0
+              bibliographic: true
+              permission: admin
+              unregistered_contributor:
+            relationships:
+              users:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/users/gyht4/
+                    meta: {}
+                data:
+                  id: gyht4
+                  type: users
+              draft_registration:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/
+                    meta: {}
+            embeds:
+              users:
+                data:
+                  id: gyht4
+                  type: users
+                  attributes:
+                    full_name: John Tordoff
+                    given_name: John
+                    middle_names: ''
+                    family_name: Tordoff
+                    suffix: ''
+                    date_registered: '2017-04-26T15:39:29.779518Z'
+                    active: true
+                    timezone: America/New_York
+                    locale: en_US
+                    social:
+                      ssrn: ''
+                      orcid: 0000-0001-8693-9390
+                      github:
+                      - Johnetordoff
+                      scholar: ''
+                      twitter: []
+                      linkedIn: []
+                      impactStory: ''
+                      baiduScholar: ''
+                      researchGate: ''
+                      researcherId: ''
+                      profileWebsites:
+                      - https://test.com
+                      academiaProfileID: ''
+                      academiaInstitution: ''
+                    employment: []
+                    education: []
+                    can_view_reviews: []
+                    accepted_terms_of_service: true
+                  relationships:
+                    nodes:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/users/gyht4/nodes/
+                          meta: {}
+                    groups:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/users/gyht4/groups/
+                          meta: {}
+                    registrations:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/users/gyht4/registrations/
+                          meta: {}
+                    institutions:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/users/gyht4/institutions/
+                          meta: {}
+                        self:
+                          href: https://api.osf.io/v2/users/gyht4/relationships/institutions/
+                          meta: {}
+                    preprints:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/users/gyht4/preprints/
+                          meta: {}
+                    emails:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/users/gyht4/settings/emails/
+                          meta: {}
+                    default_region:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/regions/us/
+                          meta: {}
+                      data:
+                        id: us
+                        type: regions
+                    settings:
+                      links:
+                        related:
+                          href: https://api.osf.io/v2/users/gyht4/settings/
+                          meta: {}
+                      data:
+                        id: gyht4
+                        type: user-settings
+                  links:
+                    html: https://osf.io/gyht4/
+                    profile_image: https://secure.gravatar.com/avatar/a61b3827662ddbc604c78e1c8f6a3636?d=identicon
+                    self: https://api.osf.io/v2/users/gyht4/
+            links:
+              self: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/contributors/gyht4/
+          meta:
+            version: '2.20'

--- a/swagger-spec/draft_registrations/draft_registrations_contributors_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_contributors_list.yaml
@@ -6,7 +6,8 @@ get:
     Contributors are users who can make changes to the Draft Registration.
 
     Contributors are categorized as either "bibliographic" or "non-bibliographic".
-    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
+    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are
+    listed on the project overview page on the OSF, while non-bibliographic contributors are not.
 
   parameters:
     - in: path

--- a/swagger-spec/draft_registrations/draft_registrations_contributors_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_contributors_list.yaml
@@ -1,0 +1,281 @@
+get:
+  summary: Retreive a list Contributors from a Draft Registration
+  description: >-
+    Retrieves the details of all given Contributors for a Draft Registration.
+
+    Contributors are users who can make changes to the Draft Registration.
+
+    Contributors are categorized as either "bibliographic" or "non-bibliographic".
+    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are listed on the project overview page on the OSF, while non-bibliographic contributors are not.
+
+  parameters:
+    - in: path
+      type: string
+      name: draft_id
+      required: true
+      description: 'The unique identifier of the Draft Registration.'
+  tags:
+    - Draft Registrations
+  operationId: draft_registration_contributors_list
+  x-response-schema: Contributor
+  consumes:
+    - application/json
+  responses:
+    '200':
+      description: 'Success'
+      examples:
+        application/json:
+          data:
+            - id: 626170854968470203611e2c-gyht4
+              type: contributors
+              attributes:
+                index: 0
+                bibliographic: true
+                permission: admin
+                unregistered_contributor:
+              relationships:
+                users:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/users/gyht4/
+                      meta: { }
+                  data:
+                    id: gyht4
+                    type: users
+                draft_registration:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/
+                      meta: { }
+              embeds:
+                users:
+                  data:
+                    id: gyht4
+                    type: users
+                    attributes:
+                      full_name: John Tordoff
+                      given_name: John
+                      middle_names: ''
+                      family_name: Tordoff
+                      suffix: ''
+                      date_registered: '2017-04-26T15:39:29.779518Z'
+                      active: true
+                      timezone: America/New_York
+                      locale: en_US
+                      social:
+                        ssrn: ''
+                        orcid: 0000-0001-8693-9390
+                        github:
+                          - Johnetordoff
+                        scholar: ''
+                        twitter: [ ]
+                        linkedIn: [ ]
+                        impactStory: ''
+                        baiduScholar: ''
+                        researchGate: ''
+                        researcherId: ''
+                        profileWebsites:
+                          - https://test.com
+                        academiaProfileID: ''
+                        academiaInstitution: ''
+                      employment: [ ]
+                      education: [ ]
+                      can_view_reviews: [ ]
+                      accepted_terms_of_service: true
+                    relationships:
+                      nodes:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/users/gyht4/nodes/
+                            meta: { }
+                      groups:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/users/gyht4/groups/
+                            meta: { }
+                      registrations:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/users/gyht4/registrations/
+                            meta: { }
+                      institutions:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/users/gyht4/institutions/
+                            meta: { }
+                          self:
+                            href: https://api.osf.io/v2/users/gyht4/relationships/institutions/
+                            meta: { }
+                      preprints:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/users/gyht4/preprints/
+                            meta: { }
+                      emails:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/users/gyht4/settings/emails/
+                            meta: { }
+                      default_region:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/regions/us/
+                            meta: { }
+                        data:
+                          id: us
+                          type: regions
+                      settings:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/users/gyht4/settings/
+                            meta: { }
+                        data:
+                          id: gyht4
+                          type: user-settings
+                    links:
+                      html: https://osf.io/gyht4/
+                      profile_image: https://secure.gravatar.com/avatar/a61b3827662ddbc604c78e1c8f6a3636?d=identicon
+                      self: https://api.osf.io/v2/users/gyht4/
+              links:
+                self: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/contributors/gyht4/
+          meta:
+            total: 1
+            per_page: 10
+            total_bibliographic: 1
+            version: '2.20'
+          links:
+            self: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/contributors/
+            first:
+            last:
+            prev:
+            next:
+
+
+
+post:
+  summary: Add a contributor to a Draft Registration
+  description: >-
+    Adds a contributor to a Draft Registration, contributors can view, edit, register or delete a Draft Registration
+    depending on their permissions.
+
+    Contributors are categorized as either "bibliographic" or "non-bibliographic" contributors.
+    From a permissions standpoint, both are the same, but bibliographic contributors are included in citations and are
+    listed on the project overview page on the OSF, while non-bibliographic contributors are not.
+
+    #### Permissions
+
+    Only project administrators can add contributors to a Draft Registration.
+
+    #### Required
+
+    A relationship object with a `data` key, containing the `users` type and valid user ID is required.
+
+    All attributes describing the relationship between the node and the user are optional.
+
+    #### Returns
+
+    Returns a JSON object with a `data` key containing the representation of the new contributor, if the request is successful.
+
+    If the request is unsuccessful, an `errors` key containing information about the failure will be returned.
+    Refer to the [list of error codes](#tag/Errors-and-Error-Codes) to understand why this request may have failed.
+
+  parameters:
+    - in: path
+      type: string
+      name: draft_id
+      required: true
+      description: 'The unique identifier of the Draft Registration.'
+    - in: body
+      name: body
+      required: true
+      schema:
+        $ref: ../nodes/contributor_definition.yaml
+  tags:
+    - Draft Registrations
+  operationId: draft_registration_contributors_create
+  x-response-schema: Contributor
+  consumes:
+    - application/json
+  responses:
+    '201':
+      description: 'Success'
+      examples:
+        application/json:
+          data:
+            id: 62718748d90ebe0012c38815-tmxzg
+            type: contributors
+            attributes:
+              index: 2
+              bibliographic: true
+              permission: write
+              unregistered_contributor:
+            relationships:
+              users:
+                links:
+                  related:
+                    href: http://localhost:8000/v2/users/tmxzg/
+                    meta: { }
+                data:
+                  id: tmxzg
+                  type: users
+              draft_registration:
+                links:
+                  related:
+                    href: http://localhost:8000/v2/draft_registrations/62718748d90ebe0012c38815/
+                    meta: { }
+            embeds:
+              users:
+                data:
+                  id: tmxzg
+                  type: users
+                  attributes:
+                    full_name: Paul Dominguez
+                    given_name: Paul
+                    middle_names: ''
+                    family_name: Dominguez
+                    suffix: ''
+                    date_registered: '2022-03-04T20:13:35.594990'
+                    active: true
+                    timezone: Etc/UTC
+                    locale: en_US
+                    social: { }
+                    employment: [ ]
+                    education: [ ]
+                  relationships:
+                    nodes:
+                      links:
+                        related:
+                          href: http://localhost:8000/v2/users/tmxzg/nodes/
+                          meta: { }
+                    groups:
+                      links:
+                        related:
+                          href: http://localhost:8000/v2/users/tmxzg/groups/
+                          meta: { }
+                    registrations:
+                      links:
+                        related:
+                          href: http://localhost:8000/v2/users/tmxzg/registrations/
+                          meta: { }
+                    institutions:
+                      links:
+                        related:
+                          href: http://localhost:8000/v2/users/tmxzg/institutions/
+                          meta: { }
+                        self:
+                          href: http://localhost:8000/v2/users/tmxzg/relationships/institutions/
+                          meta: { }
+                    preprints:
+                      links:
+                        related:
+                          href: http://localhost:8000/v2/users/tmxzg/preprints/
+                          meta: { }
+                  links:
+                    html: http://localhost:5000/tmxzg/
+                    profile_image: https://secure.gravatar.com/avatar/c16b8f65c6ac5dc8511fbffab8ef8918?d=identicon
+                    self: http://localhost:8000/v2/users/tmxzg/
+            links:
+              self: http://localhost:8000/v2/draft_registrations/62718748d90ebe0012c38815/contributors/tmxzg/
+          meta:
+            version: '2.0'
+

--- a/swagger-spec/draft_registrations/draft_registrations_institutions_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_institutions_list.yaml
@@ -1,7 +1,7 @@
 get:
   summary: Retrieve Institutions afilliated with a Draft Registration
   description: >-
-    Once a properly authenticated user has marked their registration as afilliated with an institution that institution
+    Once a properly authenticated user has marked their registration as affiliated with an institution, that institution
     and any others added will appear in this list.
 
   parameters:

--- a/swagger-spec/draft_registrations/draft_registrations_institutions_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_institutions_list.yaml
@@ -1,0 +1,80 @@
+get:
+  summary: Retrieve Institutions afilliated with a Draft Registration
+  description: >-
+    Once a properly authenticated user has marked their registration as afilliated with an institution that institution
+    and any others added will appear in this list.
+
+  parameters:
+    - in: path
+      type: string
+      name: draft_id
+      required: true
+      description: 'The unique identifier of the draft registration.'
+  tags:
+    - Draft Registrations
+  operationId: nodes_draft_registrations_read
+  x-response-schema: Draft Registration
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref:  ../institutions/definition.yaml
+      examples:
+        application/json:
+          data:
+          - id: lab
+            type: institutions
+            attributes:
+              name: Lab [Test]
+              description: Lab test
+              assets:
+                logo: "/static/img/institutions/shields/lab-shield.png"
+                logo_rounded: "/static/img/institutions/shields-rounded-corners/lab-shield-rounded-corners.png"
+            relationships:
+              nodes:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/institutions/lab/nodes/
+                    meta: {}
+              registrations:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/institutions/lab/registrations/
+                    meta: {}
+              users:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/institutions/lab/users/
+                    meta: {}
+              department_metrics:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/institutions/lab/metrics/departments/
+                    meta: {}
+              user_metrics:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/institutions/lab/metrics/users/
+                    meta: {}
+              summary_metrics:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/institutions/lab/metrics/summary/
+                    meta: {}
+                data:
+                  id: a2jlab
+                  type: institution-summary-metrics
+            links:
+              self: https://api.osf.io/v2/institutions/lab/
+              html: http://localhost:5000/institutions/lab/
+          meta:
+            total: 1
+            per_page: 10
+            version: '2.20'
+          links:
+            self: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/institutions/
+            first:
+            last:
+            prev:
+            next:
+

--- a/swagger-spec/draft_registrations/draft_registrations_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_list.yaml
@@ -125,7 +125,7 @@ post:
    This creates a Draft Registration that can be used to edit and register research.
 
    Draft Registrations contain Registration questions that will become part of the Registration.
-   A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+   A Registration is a frozen version of the project that can never be deleted, but can be withdrawn and have it's metadata edited.
 
    A Draft Registration created by this endpoint will not have a Project linked with it by default, but if the user
    includes a `branched_from` attribute in their Draft Registration creation payload with the value of the

--- a/swagger-spec/draft_registrations/draft_registrations_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_list.yaml
@@ -1,0 +1,242 @@
+get:
+  summary: Retrieve a list of Draft Registrations
+  description: >-
+    Retrieve a list of all currently available Draft Registrations for that user.
+
+    #### Permissions
+
+    Only Draft Registration contributors may view draft registrations.
+
+    #### Returns
+
+    Returns a JSON object with a `data` key containing the representation of the requested
+    draft registration, if the request is successful.
+
+
+    If the request is unsuccessful, an `errors` key containing information about the failure will be returned.
+    Refer to the [list of error codes](#tag/Errors-and-Error-Codes) to understand why this request may have failed.
+
+  tags:
+    - Draft Registrations
+  operationId: draft_registrations_read
+  x-response-schema: Draft Registration
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: draft_registration_definition.yaml
+      examples:
+        application/json:
+          data:
+              - id: 626170854968470203611e2c
+                type: draft-registrations
+                attributes:
+                  registration_metadata: { }
+                  registration_responses: { }
+                  datetime_initiated: '2022-04-21T14:56:05.674349Z'
+                  datetime_updated: '2022-04-21T14:56:05.908546Z'
+                  title: Test Draft
+                  description: 'Test'
+                  category: ''
+                  tags: [ ]
+                  node_license:
+                  current_user_permissions:
+                    - admin
+                    - write
+                    - read
+                  has_project: false
+                relationships:
+                  initiator:
+                    links:
+                      related:
+                        href: https://api.osf.io/v2/users/gyht4/
+                        meta: { }
+                    data:
+                      id: gyht4
+                      type: users
+                  branched_from:
+                    links:
+                      related:
+                        href: https://api.osf.io/v2/draft_nodes/yt5fw/
+                        meta: { }
+                    data:
+                      id: yt5fw
+                      type: draft_nodes
+                  registration_schema:
+                    links:
+                      related:
+                        href: https://api.osf.io/v2/schemas/registrations/5e795fc0d2833800195735d0/
+                        meta: { }
+                    data:
+                      id: 5e795fc0d2833800195735d0
+                      type: registration-schemas
+                  provider:
+                    links:
+                      related:
+                        href: https://api.osf.io/v2/providers/registrations/osf/
+                        meta: { }
+                    data:
+                      id: osf
+                      type: registration-providers
+                  affiliated_institutions:
+                    links:
+                      related:
+                        href: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/institutions/
+                        meta: { }
+                      self:
+                        href: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/relationships/institutions/
+                        meta: { }
+                  contributors:
+                    links:
+                      related:
+                        href: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/contributors/
+                        meta: { }
+                  bibliographic_contributors:
+                    links:
+                      related:
+                        href: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/bibliographic_contributors/
+                        meta: { }
+                  license:
+                    data:
+                  subjects:
+                    links:
+                      related:
+                        href: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/subjects/
+                        meta: { }
+                      self:
+                        href: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/relationships/subjects/
+                        meta: { }
+                links:
+                  self: https://api.osf.io/v2/draft_registrations/626170854968470203611e2c/
+          meta:
+            total: 1
+            per_page: 10
+            version: '2.20'
+          links:
+            self: https://api.osf.io/v2/draft_registrations/
+            first:
+            last:
+            prev:
+            next:
+
+post:
+ summary: Create a Draft Registration
+ description: >-
+   This creates a Draft Registration that can be used to edit and register research.
+
+   Draft Registrations contain Registration questions that will become part of the Registration.
+   A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+
+   If you based your Draft Registration on a Project, your original Project remains editable but will now have
+   the Draft Registration linked to it. However if you are using this endpoint no Project will be linked.
+
+   #### Permissions
+
+   Any user can create a Draft Registration.
+
+   #### Required
+
+   Required fields for creating a Draft Registration include:
+
+
+   &nbsp;&nbsp;&nbsp;&nbsp;`schema_id`
+
+   #### Returns
+
+   Returns a JSON object with a `data` key containing the representation of the created
+   Draft Registration, if the request is successful.
+
+
+   If the request is unsuccessful, an `errors` key containing
+   information about the failure will be returned. Refer to the [list of error codes](#tag/Errors-and-Error-Codes)
+   to understand why this request may have failed.
+
+ parameters:
+   - in: body
+     name: body
+     required: true
+     schema:
+        $ref: draft_registration_definition.yaml
+
+
+ tags:
+   - Draft Registrations
+ operationId: draft_registrations_create
+ x-response-schema: Draft Registration
+ consumes:
+   - application/json
+ responses:
+   '201':
+     description: 'Created'
+     schema:
+        $ref: draft_registration_definition.yaml
+     examples:
+      application/json:
+        data:
+          id: 62716076d90ebe0017f2bf42
+          type: draft_registrations
+          attributes:
+            registration_metadata: { }
+            registration_responses: { }
+            datetime_initiated: '2022-05-03T17:03:50.288542'
+            datetime_updated: '2022-05-03T17:03:50.560153'
+            title: Untitled
+            description: ''
+            category: ''
+            tags: [ ]
+            node_license:
+          relationships:
+            initiator:
+              links:
+                related:
+                  href: https://api.osf.io/v2/users/fgvc6/
+                  meta: { }
+              data:
+                id: fgvc6
+                type: users
+            branched_from:
+              links:
+                related:
+                  href: https://api.osf.io/v2/draft_nodes/nmj5w/
+                  meta: { }
+            registration_schema:
+              links:
+                related:
+                  href: https://api.osf.io/v2/schemas/registrations/61e02b6c90de34000ae3447a/
+                  meta: { }
+              data:
+                id: 61e02b6c90de34000ae3447a
+                type: registration-schemas
+            provider:
+              links:
+                related:
+                  href: https://api.osf.io/v2/providers/registrations/osf/
+                  meta: { }
+              data:
+                id: osf
+                type: registration-providers
+            affiliated_institutions:
+              links:
+                related:
+                  href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/institutions/
+                  meta: { }
+                self:
+                  href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/relationships/institutions/
+                  meta: { }
+            contributors:
+              links:
+                related:
+                  href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/contributors/
+                  meta: { }
+            subjects:
+              links:
+                related:
+                  href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/subjects/
+                  meta: { }
+                self:
+                  href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/relationships/subjects/
+                  meta: { }
+          links:
+            self: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/
+        meta:
+          version: '2.0'

--- a/swagger-spec/draft_registrations/draft_registrations_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_list.yaml
@@ -127,8 +127,11 @@ post:
    Draft Registrations contain Registration questions that will become part of the Registration.
    A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
 
-   If you based your Draft Registration on a Project, your original Project remains editable but will now have
-   the Draft Registration linked to it. However if you are using this endpoint no Project will be linked.
+   A Draft Registration created by this endpoint will not have a Project linked with it by default, but if the user
+   includes a `branched_from` attribute in their Draft Registration creation payload with the value of the
+   `branched_from` being guid of a Project they have permissions for the Draft Registration will be linked to the
+   Project. If you linked your Draft Registration on a Project, your original Project remains editable and will now have
+   the Draft Registration linked to it. 
 
    #### Permissions
 
@@ -157,8 +160,6 @@ post:
      required: true
      schema:
         $ref: draft_registration_definition.yaml
-
-
  tags:
    - Draft Registrations
  operationId: draft_registrations_create

--- a/swagger-spec/draft_registrations/draft_registrations_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_list.yaml
@@ -135,7 +135,7 @@ post:
 
    #### Permissions
 
-   Any user can create a Draft Registration.
+   Any user can create a Draft Registration. If the `branched_from` attribute is provided, then the user must be an ADMIN contributor on the Project being registered.
 
    #### Required
 

--- a/swagger-spec/draft_registrations/draft_registrations_subjects_list.yaml
+++ b/swagger-spec/draft_registrations/draft_registrations_subjects_list.yaml
@@ -1,0 +1,76 @@
+get:
+  summary: Retrieve Subjects associated with a Draft Registration
+  description: >-
+    This retrieves a list of subjects associated with a Draft Registration. Subjects are formatted here in a flat
+    paginated list, but are hierarchical and nested by specificity of subject matter.
+  parameters:
+    - in: path
+      type: string
+      name: draft_id
+      required: true
+      description: 'The unique identifier of the draft registration.'
+  tags:
+    - Draft Registrations
+  operationId: nodes_draft_registrations_subjects
+  x-response-schema: Draft Registration
+  responses:
+    '200':
+      description: 'OK'
+      schema:
+        $ref: ../subjects/subject_definition.yaml
+      examples:
+        application/json:
+          data:
+            - id: 61e02bee90de34000ae3449e
+              type: subjects
+              attributes:
+                text: Philosophy
+                taxonomy_name: ''
+              relationships:
+                parent:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/subjects/61e02bee90de34000ae344b5/
+                      meta: { }
+                  data:
+                    id: 61e02bee90de34000ae344b5
+                    type: subjects
+                children:
+                  links:
+                    related:
+                      href: https://api.osf.io/v2/subjects/61e02bee90de34000ae3449e/children/
+                      meta: { }
+              embeds:
+                parent:
+                  data:
+                    id: 61e02bee90de34000ae344b5
+                    type: subjects
+                    attributes:
+                      text: Arts and Humanities
+                      taxonomy_name: ''
+                    relationships:
+                      parent:
+                        data:
+                      children:
+                        links:
+                          related:
+                            href: https://api.osf.io/v2/subjects/61e02bee90de34000ae344b5/children/
+                            meta: { }
+                    embeds:
+                      parent:
+                        errors:
+                          - detail: Not found.
+                    links:
+                      self: https://api.osf.io/v2/subjects/61e02bee90de34000ae344b5/
+              links:
+                self: https://api.osf.io/v2/subjects/61e02bee90de34000ae3449e/
+          meta:
+            total: 1
+            per_page: 10
+            version: '2.20'
+          links:
+            self: https://api.osf.io/v2/draft_registrations/626ffc1ad90ebe0011fc7601/subjects/
+            first:
+            last:
+            prev:
+            next:

--- a/swagger-spec/nodes/contributor_definition.yaml
+++ b/swagger-spec/nodes/contributor_definition.yaml
@@ -74,4 +74,4 @@ example:
       user:
         data:
           type: users
-          id: '{user_id}'
+          id: 'guid0'

--- a/swagger-spec/nodes/draft_registration_detail.yaml
+++ b/swagger-spec/nodes/draft_registration_detail.yaml
@@ -4,7 +4,7 @@ get:
     Retrieve the details of a given draft registration.
 
     Draft Registrations contain Registration questions that will become part of the Registration.
-    A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+    A Registration is a frozen version of the project that can never be deleted, but can be withdrawn and have it's metadata edited.
 
 
     Your original project remains editable but will now have the draft registration linked to it.

--- a/swagger-spec/nodes/draft_registration_detail.yaml
+++ b/swagger-spec/nodes/draft_registration_detail.yaml
@@ -1,10 +1,10 @@
 get:
-  summary: Retrieve a draft registration
+  summary: Retrieve a Draft Registration
   description: >-
     Retrieve the details of a given draft registration.
 
-    Draft registrations contain the supplemental registration questions that accompany a registration.
-    A registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+    Draft Registrations contain Registration questions that will become part of the Registration.
+    A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
 
 
     Your original project remains editable but will now have the draft registration linked to it.
@@ -34,14 +34,14 @@ get:
       required: true
       description: 'The unique identifier of the draft registration.'
   tags:
-    - Nodes
+    - Draft Registrations
   operationId: nodes_draft_registrations_read
   x-response-schema: Draft Registration
   responses:
     '200':
       description: 'OK'
       schema:
-        $ref: draft_registration_definition.yaml
+        $ref:  ../draft_registrations/draft_registration_definition.yaml
       examples:
         application/json:
           data:
@@ -86,7 +86,7 @@ patch:
     Any unspecified attributes will be left unchanged.
 
 
-    Draft registrations contain the supplemental registration questions that accompany a registration.
+    Draft Registrations contain Registration questions that will become part of the Registration.
     Answer the questions in the draft registration supplement by sending update requests until you are ready to submit the draft.
 
 
@@ -127,7 +127,7 @@ patch:
       name: body
       required: true
       schema:
-        $ref: draft_registration_definition.yaml
+        $ref:  ../draft_registrations/draft_registration_definition.yaml
   tags:
     - Nodes
   operationId: nodes_draft_registrations_partial_update

--- a/swagger-spec/nodes/draft_registrations_list.yaml
+++ b/swagger-spec/nodes/draft_registrations_list.yaml
@@ -5,7 +5,7 @@ get:
 
 
     Draft Registrations contain Registration questions that will become part of the Registration.
-    A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+    A Registration is a frozen version of the project that can never be deleted, but can be withdrawn and have it's metadata edited.
 
 
     Your original project remains editable but will now have the draft registration linked to it.
@@ -127,7 +127,7 @@ post:
    Initiate a draft registration of the current node.
 
    Draft Registrations contain Registration questions that will become part of the Registration.
-   A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+   A Registration is a frozen version of the project that can never be deleted, but can be withdrawn and have it's metadata edited.
 
 
    Your original project remains editable but will now have the draft registration linked to it.

--- a/swagger-spec/nodes/draft_registrations_list.yaml
+++ b/swagger-spec/nodes/draft_registrations_list.yaml
@@ -4,8 +4,8 @@ get:
     A paginated list of all of the draft registrations of a given node.
 
 
-    Draft registrations contain the supplemental registration questions that accompany a registration.
-    A registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
+    Draft Registrations contain Registration questions that will become part of the Registration.
+    A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
 
 
     Your original project remains editable but will now have the draft registration linked to it.
@@ -43,35 +43,75 @@ get:
       schema:
         type: array
         items:
-          $ref: draft_registration_definition.yaml
+          $ref: ../draft_registrations/draft_registration_definition.yaml
       examples:
         application/json:
           data:
-          - id: ''
-            type: 'draft_registrations'
+          - id: 62716076d90ebe0017f2bf42
+            type: draft_registrations
             attributes:
-              datetime_initiated: ''
-              datetime_updated: ''
-              registration_metadata: {}
-              registration_supplement: ''
+              registration_metadata: { }
+              registration_responses: { }
+              datetime_initiated: '2022-05-03T17:03:50.288542'
+              datetime_updated: '2022-05-03T17:03:50.560153'
+              title: Untitled
+              description: ''
+              category: ''
+              tags: [ ]
+              node_license:
             relationships:
-              branched_from:
-                links:
-                  related:
-                    href: ''
-                    meta: {}
               initiator:
                 links:
                   related:
-                    href: ''
-                    meta: {}
+                    href: https://api.osf.io/v2/users/fgvc6/
+                    meta: { }
+                data:
+                  id: fgvc6
+                  type: users
+              branched_from:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_nodes/nmj5w/
+                    meta: { }
               registration_schema:
                 links:
                   related:
-                    href: ''
-                    meta: {}
+                    href: https://api.osf.io/v2/schemas/registrations/61e02b6c90de34000ae3447a/
+                    meta: { }
+                data:
+                  id: 61e02b6c90de34000ae3447a
+                  type: registration-schemas
+              provider:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/providers/registrations/osf/
+                    meta: { }
+                data:
+                  id: osf
+                  type: registration-providers
+              affiliated_institutions:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/institutions/
+                    meta: { }
+                  self:
+                    href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/relationships/institutions/
+                    meta: { }
+              contributors:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/contributors/
+                    meta: { }
+              subjects:
+                links:
+                  related:
+                    href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/subjects/
+                    meta: { }
+                  self:
+                    href: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/relationships/subjects/
+                    meta: { }
             links:
-              html: ''
+              self: https://api.osf.io/v2/draft_registrations/62716076d90ebe0017f2bf42/
           links:
             first: ''
             last: ''
@@ -82,54 +122,54 @@ get:
               per_page: 10
 
 post:
-  summary: Create a draft registration
-  description: >-
-    Initiate a draft registration of the current node.
+ summary: Create a draft registration based on your current project Node.
+ description: >-
+   Initiate a draft registration of the current node.
 
-    Draft registrations contain the supplemental registration questions that accompany a registration.
-    A registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
-
-
-    Your original project remains editable but will now have the draft registration linked to it.
-
-    #### Permissions
-
-    Only project administrators may view create registrations.
-
-    #### Required
-
-    Required fields for creating a draft registration include:
+   Draft Registrations contain Registration questions that will become part of the Registration.
+   A Registration is a frozen version of the project that can never be edited or deleted, but can be withdrawn.
 
 
-    &nbsp;&nbsp;&nbsp;&nbsp`registration_supplement`
+   Your original project remains editable but will now have the draft registration linked to it.
 
-    #### Returns
+   #### Permissions
 
-    Returns a JSON object with a `data` key containing the representation of the created
-    draft registration, if the request is successful.
+   Only project administrators may view create registrations.
+
+   #### Required
+
+   Required fields for creating a draft registration include:
 
 
-    If the request is unsuccessful, an `errors` key containing
-    information about the failure will be returned. Refer to the [list of error codes](#tag/Errors-and-Error-Codes)
-    to understand why this request may have failed.
+   &nbsp;&nbsp;&nbsp;&nbsp;`schema_id`
 
-  parameters:
-    - in: path
-      type: string
-      name: node_id
-      required: true
-      description: 'The unique identifier of the node.'
-    - in: body
-      name: body
-      required: true
-      schema:
-        $ref: draft_registration_definition.yaml
-  tags:
-    - Nodes
-  operationId: nodes_draft_registrations_create
-  x-response-schema: Draft Registration
-  consumes:
-    - application/json
-  responses:
-    '201':
-      description: 'Created'
+   #### Returns
+
+   Returns a JSON object with a `data` key containing the representation of the created
+   draft registration, if the request is successful.
+
+
+   If the request is unsuccessful, an `errors` key containing
+   information about the failure will be returned. Refer to the [list of error codes](#tag/Errors-and-Error-Codes)
+   to understand why this request may have failed.
+
+ parameters:
+   - in: path
+     type: string
+     name: node_id
+     required: true
+     description: 'The unique identifier of the node.'
+   - in: body
+     name: body
+     required: true
+     schema:
+       $ref: ../draft_registrations/draft_registration_definition.yaml
+ tags:
+   - Nodes
+ operationId: nodes_draft_registrations_create
+ x-response-schema: Draft Registration
+ consumes:
+   - application/json
+ responses:
+   '201':
+     description: 'Created'

--- a/swagger-spec/nodes/draft_registrations_list.yaml
+++ b/swagger-spec/nodes/draft_registrations_list.yaml
@@ -71,7 +71,7 @@ get:
               branched_from:
                 links:
                   related:
-                    href: https://api.osf.io/v2/draft_nodes/nmj5w/
+                    href: https://api.osf.io/v2/nodes/nmj5w/
                     meta: { }
               registration_schema:
                 links:

--- a/swagger-spec/preprint_providers/licenses_list.yaml
+++ b/swagger-spec/preprint_providers/licenses_list.yaml
@@ -2,7 +2,7 @@ get:
   summary: List all licenses
   description: >-
 
-    A paginated list of the licenses allowed bya preprint provider.
+    A paginated list of the licenses allowed by a preprint provider.
 
     #### Returns
 

--- a/swagger-spec/subjects/subject_definition.yaml
+++ b/swagger-spec/subjects/subject_definition.yaml
@@ -7,59 +7,59 @@ properties:
     description: 'The unique identifier of the Subject.'
   type:
     type: string
-    readOnly: false
+    readOnly: true
     description: 'The type identifier of the Subject (`subject`).'
   attributes:
     type: object
     title: Attributes
-    readOnly: false
+    readOnly: true
     description: 'The attributes of the Subject.'
     properties:
       text:
         type: string
-        readOnly: false
+        readOnly: true
         description: 'The name for the subject (`Arts and Humanities`)'
       taxonomy_name:
         type: string
-        readOnly: false
+        readOnly: true
         description: 'The name for the taxonomy used to name subjects (`bepress`)'
   relationships:
     type: object
     title: Relationships
-    readOnly: false
+    readOnly: true
     description: 'Links to other entities or entity collections that have a relationship to the file entity.'
     properties:
       parent:
         type: string
         format: URL
-        readOnly: false
+        readOnly: true
         description: 'A link to the parent for this Subject.'
       children:
         type: string
         format: URL
-        readOnly: false
+        readOnly: true
         description: 'A link to the children for this Subject.'
   embeds:
     type: object
     title: Embeds
-    readOnly: false
+    readOnly: true
     description: 'The the parent is always embedded in the Subject response.'
     properties:
       parent:
         type: object
         title: parent
-        readOnly: false
+        readOnly: true
         description: 'The the parent of the Subject.'
         properties:
           data:
             type: object
             title: data
-            readOnly: false
+            readOnly: true
             properties:
               data:
                 type: object
                 title: data
-                readOnly: false
+                readOnly: true
                 description: 'A JSON object containing the embedded information.'
               id:
                 type: string
@@ -67,46 +67,46 @@ properties:
                 description: 'The unique identifier of the Subject.'
               type:
                 type: string
-                readOnly: false
+                readOnly: true
                 description: 'The type identifier of the Subject (`subject`).'
               attributes:
                 type: object
                 title: Attributes
-                readOnly: false
+                readOnly: true
                 description: 'The attributes of the Subject.'
                 properties:
                   text:
                     type: string
-                    readOnly: false
+                    readOnly: true
                     description: 'The name for the subject (`Arts and Humanities`)'
                   taxonomy_name:
                     type: string
-                    readOnly: false
+                    readOnly: true
                     description: 'The name for the taxonmy used to name subjects (`bepress`)'
               relationships:
                 type: object
                 title: Relationships
-                readOnly: false
+                readOnly: true
                 description: 'Links to other entities or entity collections that have a relationship to the file entity.'
                 properties:
                   parent:
                     type: string
                     format: URL
-                    readOnly: false
+                    readOnly: true
                     description: 'A link to the parent for this Subject.'
                   children:
                     type: string
                     format: URL
-                    readOnly: false
+                    readOnly: true
                     description: 'A link to the children for this Subject.'
   links:
     type: object
     title: Links
-    readOnly: false
+    readOnly: true
     description: 'URLs to alternative representations of the Subject entity.'
     properties:
       self:
         type: string
         format: URL
-        readOnly: false
+        readOnly: true
         description: 'A link to the detail page for a Subject.'

--- a/swagger-spec/subjects/subject_definition.yaml
+++ b/swagger-spec/subjects/subject_definition.yaml
@@ -1,0 +1,112 @@
+type: object
+title: Subject
+properties:
+  id:
+    type: string
+    readOnly: true
+    description: 'The unique identifier of the Subject.'
+  type:
+    type: string
+    readOnly: false
+    description: 'The type identifier of the Subject (`subject`).'
+  attributes:
+    type: object
+    title: Attributes
+    readOnly: false
+    description: 'The attributes of the Subject.'
+    properties:
+      text:
+        type: string
+        readOnly: false
+        description: 'The name for the subject (`Arts and Humanities`)'
+      taxonomy_name:
+        type: string
+        readOnly: false
+        description: 'The name for the taxonomy used to name subjects (`bepress`)'
+  relationships:
+    type: object
+    title: Relationships
+    readOnly: false
+    description: 'Links to other entities or entity collections that have a relationship to the file entity.'
+    properties:
+      parent:
+        type: string
+        format: URL
+        readOnly: false
+        description: 'A link to the parent for this Subject.'
+      children:
+        type: string
+        format: URL
+        readOnly: false
+        description: 'A link to the children for this Subject.'
+  embeds:
+    type: object
+    title: Embeds
+    readOnly: false
+    description: 'The the parent is always embedded in the Subject response.'
+    properties:
+      parent:
+        type: object
+        title: parent
+        readOnly: false
+        description: 'The the parent of the Subject.'
+        properties:
+          data:
+            type: object
+            title: data
+            readOnly: false
+            properties:
+              data:
+                type: object
+                title: data
+                readOnly: false
+                description: 'A JSON object containing the embedded information.'
+              id:
+                type: string
+                readOnly: true
+                description: 'The unique identifier of the Subject.'
+              type:
+                type: string
+                readOnly: false
+                description: 'The type identifier of the Subject (`subject`).'
+              attributes:
+                type: object
+                title: Attributes
+                readOnly: false
+                description: 'The attributes of the Subject.'
+                properties:
+                  text:
+                    type: string
+                    readOnly: false
+                    description: 'The name for the subject (`Arts and Humanities`)'
+                  taxonomy_name:
+                    type: string
+                    readOnly: false
+                    description: 'The name for the taxonmy used to name subjects (`bepress`)'
+              relationships:
+                type: object
+                title: Relationships
+                readOnly: false
+                description: 'Links to other entities or entity collections that have a relationship to the file entity.'
+                properties:
+                  parent:
+                    type: string
+                    format: URL
+                    readOnly: false
+                    description: 'A link to the parent for this Subject.'
+                  children:
+                    type: string
+                    format: URL
+                    readOnly: false
+                    description: 'A link to the children for this Subject.'
+  links:
+    type: object
+    title: Links
+    readOnly: false
+    description: 'URLs to alternative representations of the Subject entity.'
+    properties:
+      self:
+        type: string
+        format: URL
+        readOnly: false
+        description: 'A link to the detail page for a Subject.'

--- a/swagger-spec/subjects/subject_definition.yaml
+++ b/swagger-spec/subjects/subject_definition.yaml
@@ -49,7 +49,7 @@ properties:
         type: object
         title: parent
         readOnly: true
-        description: 'The the parent of the Subject.'
+        description: 'The parent of the Subject.'
         properties:
           data:
             type: object

--- a/swagger-spec/subjects/subject_definition.yaml
+++ b/swagger-spec/subjects/subject_definition.yaml
@@ -43,7 +43,7 @@ properties:
     type: object
     title: Embeds
     readOnly: true
-    description: 'The the parent is always embedded in the Subject response.'
+    description: 'The parent is always embedded in the Subject response.'
     properties:
       parent:
         type: object

--- a/swagger-spec/swagger.yaml
+++ b/swagger-spec/swagger.yaml
@@ -49,6 +49,7 @@ x-tagGroups:
       - Nodes
       - Preprints
       - Preprint Providers
+      - Draft Registrations
       - Registrations
       - Taxonomies
       - Users
@@ -788,7 +789,12 @@ tags:
         `in_progress`  state. This trigger is only valid for Schema Responses that are associated with a Registration
         that has Registration Provider a moderated workflow and only possible for a user designated as moderator of a
         Registration Provider.
+  - name: Draft Registrations
+    description: >-
 
+      A Draft Registration is a object that allows a user to edit and revise a registration before it is registered.
+      Draft Registrations allow contributors to coordinate on a single registration, so they can upload files and change
+      Registration metadata before the Registration is archived.
 
 
 paths:
@@ -1030,11 +1036,6 @@ paths:
   /nodes/{node_id}/wikis/:
     $ref: 'nodes/wikis_list.yaml'
 
-  #/nodes/{node_id}/relationships/institutions:
-  #  $ref: 'nodes/institutions_relationships.yaml'
-
-  #/nodes/{node_id}/relationships/linked_nodes:
-  #  $ref: 'nodes/linked_nodes_relationships.yaml'
 
   #################
   #   PREPRINTS   #
@@ -1132,6 +1133,28 @@ paths:
 
   /registrations/{registration_id}/wikis/:
     $ref: 'registrations/wikis_list.yaml'
+
+  ##########################
+  #  DRAFT REGISTRATIONS   #
+  ##########################
+
+  /draft_registrations/:
+    $ref: 'draft_registrations/draft_registrations_list.yaml'
+
+  /draft_registrations/{draft_id}/:
+    $ref: 'draft_registrations/draft_registration_detail.yaml'
+
+  /draft_registrations/{draft_id}/contributors/:
+    $ref: 'draft_registrations/draft_registrations_contributors_list.yaml'
+
+  /draft_registrations/{draft_id}/contributors/{user_id}/:
+    $ref: 'draft_registrations/draft_registrations_contributors_detail.yaml'
+
+  /draft_registrations/{draft_id}/institutions/:
+    $ref: 'draft_registrations/draft_registrations_institutions_list.yaml'
+
+  /draft_registrations/{draft_id}/subjects/:
+    $ref: 'draft_registrations/draft_registrations_subjects_list.yaml'
 
   ##################
   #   TAXONOMIES   #


### PR DESCRIPTION
Add no-project registrations and PATHCHing, contributor adding and other modern Draft Registration behavior
  
```yaml
 ##########################
  #  DRAFT REGISTRATIONS   #
  ##########################

  /draft_registrations/:
    $ref: 'draft_registrations/draft_registrations_list.yaml'

  /draft_registrations/{draft_id}/:
    $ref: 'draft_registrations/draft_registration_detail.yaml'

  /draft_registrations/{draft_id}/contributors/:
    $ref: 'draft_registrations/draft_registrations_contributors_list.yaml'

  /draft_registrations/{draft_id}/contributors/{user_id}/:
    $ref: 'draft_registrations/draft_registrations_contributors_detail.yaml'

  /draft_registrations/{draft_id}/institutions/:
    $ref: 'draft_registrations/draft_registrations_institutions_list.yaml'

  /draft_registrations/{draft_id}/subjects/:
    $ref: 'draft_registrations/draft_registrations_subjects_list.yaml'
```

Ticket:
https://openscience.atlassian.net/browse/ENG-2480